### PR TITLE
[BE/FEAT, BE/REFACTOR] #46 - 유저 프로필 수정 API 구현 및 포지션 구조 리팩토링

### DIFF
--- a/be/src/main/java/com/example/mingle/domain/user/user/controller/ApiV1AuthController.java
+++ b/be/src/main/java/com/example/mingle/domain/user/user/controller/ApiV1AuthController.java
@@ -1,9 +1,6 @@
 package com.example.mingle.domain.user.user.controller;
 
-import com.example.mingle.domain.user.user.dto.SignupRequestDto;
-import com.example.mingle.domain.user.user.dto.TokenResponseDto;
-import com.example.mingle.domain.user.user.dto.LoginRequestDto;
-import com.example.mingle.domain.user.user.dto.UserResponseDto;
+import com.example.mingle.domain.user.user.dto.*;
 import com.example.mingle.domain.user.user.entity.User;
 import com.example.mingle.domain.user.user.service.UserService;
 import com.example.mingle.global.rq.Rq;
@@ -116,6 +113,28 @@ public class ApiV1AuthController {
 
         return ResponseEntity.ok(UserResponseDto.fromEntity(user)); // DTO 변환 후 반환
     }
+
+
+
+    /**
+     * 내 프로필 수정
+     * → 현재 로그인한 사용자가 자신의 닉네임, 이메일, 전화번호, 이미지URL을 수정
+     */
+    @Operation(summary = "내 프로필 수정", description = "로그인한 사용자의 프로필 정보를 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "수정 성공")
+    @PatchMapping("/me")
+    public ResponseEntity<ProfileResponseDto> updateMyProfile(
+            @RequestBody ProfileUpdateRequestDto requestDto
+    ) {
+        User actor = rq.getActor(); // 현재 로그인한 사용자 조회
+        if (actor == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        User updated = userService.updateMyProfile(actor, requestDto);
+        return ResponseEntity.ok(ProfileResponseDto.fromEntity(updated));
+    }
+
 
 
 

--- a/be/src/main/java/com/example/mingle/domain/user/user/dto/ProfileResponseDto.java
+++ b/be/src/main/java/com/example/mingle/domain/user/user/dto/ProfileResponseDto.java
@@ -1,4 +1,25 @@
 package com.example.mingle.domain.user.user.dto;
 
+import com.example.mingle.domain.user.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
 public class ProfileResponseDto {
+    private String nickname;
+    private String email;
+    private String position; // 직책
+    private String phoneNum;
+    private String imageUrl;
+
+    public static ProfileResponseDto fromEntity(User user) {
+        return ProfileResponseDto.builder()
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .position(user.getPosition()) // 직책
+                .phoneNum(user.getPhoneNum())
+                .imageUrl(user.getImageUrl())
+                .build();
+    }
 }

--- a/be/src/main/java/com/example/mingle/domain/user/user/dto/ProfileUpdateRequestDto.java
+++ b/be/src/main/java/com/example/mingle/domain/user/user/dto/ProfileUpdateRequestDto.java
@@ -1,4 +1,12 @@
 package com.example.mingle.domain.user.user.dto;
 
+import lombok.Getter;
+
+@Getter
 public class ProfileUpdateRequestDto {
+    private String nickname;
+    private String email;
+    private String position; // 직책
+    private String phoneNum;
+    private String imageUrl;
 }

--- a/be/src/main/java/com/example/mingle/domain/user/user/dto/SignupRequestDto.java
+++ b/be/src/main/java/com/example/mingle/domain/user/user/dto/SignupRequestDto.java
@@ -19,6 +19,8 @@ public class SignupRequestDto {
     @NotBlank(message = "부서이름은 필수 입력값입니다.")
     private String departmentName;
 
+    private Long positionId; // 포지션 ID (UserPosition 참조용)
+
     private String nickname;
     private String email;
     private String phoneNum;

--- a/be/src/main/java/com/example/mingle/domain/user/user/entity/PositionCode.java
+++ b/be/src/main/java/com/example/mingle/domain/user/user/entity/PositionCode.java
@@ -1,0 +1,39 @@
+package com.example.mingle.domain.user.user.entity;
+
+public enum PositionCode {
+
+    // Planning & A&R 부서
+    CONTENTS_STRATEGIST,
+    A_AND_R_PLANNER,
+    DEMO_CURATOR,
+
+    // Creative Studio 부서
+    VISUAL_DESIGNER,
+    MOTION_CREATOR,
+    CREATIVE_EDITOR,
+
+    // Finance & Legal 부서
+    FINANCE_PARTNER,
+    LEGAL_ASSISTANT,
+    CONTRACT_COORDINATOR,
+
+    // Marketing & PR 부서
+    SOCIAL_MEDIA_MANAGER,
+    BRAND_DESIGNER,
+    MEDIA_PLANNER,
+
+    // Artist & Manager 부서
+    ARTIST_COORDINATOR,
+    FAN_COMMUNICATION_LEAD,
+    SCHEDULE_MANAGER,
+
+    // System Operations 부서
+    WEBOPS_MANAGER,
+    INFRA_COORDINATOR,
+    TECHOPS_PARTNER,
+
+    // Executive 부서
+    STRATEGY_LEAD,
+    EXECUTIVE_ASSISTANT,
+    CHIEF_CULTURE_OFFICER
+}

--- a/be/src/main/java/com/example/mingle/domain/user/user/entity/User.java
+++ b/be/src/main/java/com/example/mingle/domain/user/user/entity/User.java
@@ -37,6 +37,25 @@ public class User extends BaseEntity {
     @Column(name = "email", length = 100)
     private String email;
 
+    // 어떤 권한 갖고 있는지
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    private UserRole role;
+
+    // 어느 팀 소속인지
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "department_id")
+    private Department department;
+
+    // 어떤 직책 맡고 있는지
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "position_id")
+    private UserPosition position;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private UserStatus status;
+
     @Column(name = "phone_num", length = 20)
     private String phoneNum;
 
@@ -45,18 +64,6 @@ public class User extends BaseEntity {
 
     @Column(name = "refresh_token", length = 255)
     private String refreshToken;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "role", nullable = false)
-    private UserRole role;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
-    private UserStatus status;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "department_id")
-    private Department department;
 
     // 권한 반환
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/be/src/main/java/com/example/mingle/domain/user/user/entity/UserPosition.java
+++ b/be/src/main/java/com/example/mingle/domain/user/user/entity/UserPosition.java
@@ -1,0 +1,25 @@
+package com.example.mingle.domain.user.user.entity;
+
+import jakarta.persistence.*;
+
+import com.example.mingle.domain.user.team.entity.Department;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserPosition {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private PositionCode code;
+
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Department department;
+}

--- a/be/src/main/java/com/example/mingle/domain/user/user/repository/UserPositionRepository.java
+++ b/be/src/main/java/com/example/mingle/domain/user/user/repository/UserPositionRepository.java
@@ -1,0 +1,7 @@
+package com.example.mingle.domain.user.user.repository;
+
+import com.example.mingle.domain.user.user.entity.UserPosition;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserPositionRepository extends JpaRepository<UserPosition, Long> {
+}

--- a/be/src/main/java/com/example/mingle/global/init/AdminInitializer.java
+++ b/be/src/main/java/com/example/mingle/global/init/AdminInitializer.java
@@ -2,9 +2,8 @@ package com.example.mingle.global.init;
 
 import com.example.mingle.domain.user.team.entity.Department;
 import com.example.mingle.domain.user.team.repository.DepartmentRepository;
-import com.example.mingle.domain.user.user.entity.User;
-import com.example.mingle.domain.user.user.entity.UserRole;
-import com.example.mingle.domain.user.user.entity.UserStatus;
+import com.example.mingle.domain.user.user.entity.*;
+import com.example.mingle.domain.user.user.repository.UserPositionRepository;
 import com.example.mingle.domain.user.user.repository.UserRepository;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +18,7 @@ public class AdminInitializer {
 
     private final UserRepository userRepository;
     private final DepartmentRepository departmentRepository;
+    private final UserPositionRepository userPositionRepository;
     private final PasswordEncoder passwordEncoder;
 
     @PostConstruct
@@ -26,15 +26,22 @@ public class AdminInitializer {
         // 이미 존재하면 중복 생성 방지
         if (userRepository.existsByLoginId("admin@admin.com")) return;
 
-        // "System Operations" 부서 존재 여부 먼저 확인
-        if (!departmentRepository.existsByDepartmentName("System Operations")) {
-            log.warn("[AdminInitializer] 'System Operations' 부서가 아직 없어 관리자 계정 생성을 건너뜁니다.");
-            return;
-        }
-
         // System Operations 부서 조회 또는 예외
         Department sysOps = departmentRepository.findByDepartmentName("System Operations")
-                .orElseThrow(() -> new IllegalStateException("System Operations 부서가 먼저 생성되어야 합니다."));
+                .orElseThrow(() -> {
+                    log.warn("[AdminInitializer] 'System Operations' 부서가 아직 없어 관리자 계정 생성을 건너뜁니다.");
+                    return new IllegalStateException("System Operations 부서가 먼저 생성되어야 합니다.");
+                });
+
+        // 포지션 확인: WEBOPS_MANAGER
+        UserPosition position = userPositionRepository.findAll().stream()
+                .filter(p -> p.getDepartment().getDepartmentName().equals("System Operations"))
+                .filter(p -> p.getCode() == PositionCode.WEBOPS_MANAGER)
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("WebOps Manager 포지션이 필요합니다."));
+
+
+
 
         // 시스템 관리자 계정 생성
         userRepository.save(User.builder()
@@ -47,6 +54,7 @@ public class AdminInitializer {
                 .role(UserRole.ADMIN)
                 .status(UserStatus.ONLINE)
                 .department(sysOps)
+                .position(position)
                 .build());
     }
 }

--- a/be/src/main/java/com/example/mingle/global/init/StaffInitializer.java
+++ b/be/src/main/java/com/example/mingle/global/init/StaffInitializer.java
@@ -2,9 +2,8 @@ package com.example.mingle.global.init;
 
 import com.example.mingle.domain.user.team.entity.Department;
 import com.example.mingle.domain.user.team.repository.DepartmentRepository;
-import com.example.mingle.domain.user.user.entity.User;
-import com.example.mingle.domain.user.user.entity.UserRole;
-import com.example.mingle.domain.user.user.entity.UserStatus;
+import com.example.mingle.domain.user.user.entity.*;
+import com.example.mingle.domain.user.user.repository.UserPositionRepository;
 import com.example.mingle.domain.user.user.repository.UserRepository;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
@@ -12,8 +11,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-import java.util.Random;
+import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 @Slf4j
@@ -23,30 +22,36 @@ public class StaffInitializer {
 
     private final UserRepository userRepository;
     private final DepartmentRepository departmentRepository;
+    private final UserPositionRepository userPositionRepository;
     private final PasswordEncoder passwordEncoder;
 
     private final Random random = new Random();
 
     @PostConstruct
     public void init() {
-        // 1. 중복 유저 존재 확인
+        // 1. staff001 계정이 이미 있으면 skip
         boolean alreadyExists = userRepository.existsByLoginId("staff001");
         if (alreadyExists) return;
 
-        // 2. 부서 존재 여부 선방어 처리
-        if (departmentRepository.count() == 0) {
+        // 2. 부서 또는 직책 없으면 skip
+        if (departmentRepository.count() == 0 || userPositionRepository.count() == 0) {
             log.warn("[StaffInitializer] 부서가 아직 생성되지 않아 스태프 유저 생성을 건너뜁니다.");
             return;
         }
 
-        // 3. 부서 목록 조회
+        // 3. 전체 부서 및 포지션 불러오기
         List<Department> departments = departmentRepository.findAll();
+        List<UserPosition> positions = userPositionRepository.findAll();
 
-        if (departments.isEmpty()) {
-            throw new IllegalStateException("부서가 먼저 생성되어야 합니다.");
-        }
+        // 4. 부서명 → 포지션 매핑
+        Map<String, List<UserPosition>> positionMap = positions.stream()
+                .collect(Collectors.groupingBy(p -> p.getDepartment().getDepartmentName()));
 
-        // 대표 테스트 계정 생성: staff001
+
+
+        // 계정 생성
+
+        // 대표 계정 staff001 생성 (Planning & A&R, A&R Planner 고정)
         /**
          * 언제나 존재하는, 프론트엔드/Swagger 테스트용 계정. (나머지 랜덤 더미 유저들과 구분하여 생성)
          * → 안정성 보장.
@@ -58,16 +63,22 @@ public class StaffInitializer {
         Department planning = departmentRepository.findByDepartmentName("Planning & A&R")
                 .orElseThrow(() -> new IllegalStateException("Planning & A&R 부서가 존재해야 합니다."));
 
+        UserPosition defaultPosition = positionMap.getOrDefault("Planning & A&R", List.of()).stream()
+                .filter(p -> p.getCode() == PositionCode.A_AND_R_PLANNER)
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("A&R Planner 포지션이 필요합니다."));
+
         userRepository.save(User.builder()
                 .loginId("staff001")
                 .password(passwordEncoder.encode("staff1234!"))
-                .nickname("A&R 담당자")
+                .nickname("avocado")
                 .email("staff001@mingle.com")
                 .phoneNum("010-0000-0001")
                 .imageUrl(null)
                 .role(UserRole.STAFF)
-                .status(UserStatus.ONLINE)
                 .department(planning)
+                .position(defaultPosition) // 직책
+                .status(UserStatus.ONLINE)
                 .build());
 
         // 더미 스태프 유저 30명 생성: staff002 ~ staff031
@@ -77,6 +88,12 @@ public class StaffInitializer {
          */
         IntStream.rangeClosed(2, 31).forEach(i -> {
             Department randomDept = departments.get(random.nextInt(departments.size()));
+            String deptName = randomDept.getDepartmentName();
+
+            List<UserPosition> deptPositions = positionMap.getOrDefault(deptName, List.of());
+            if (deptPositions.isEmpty()) return; // 해당 부서에 포지션 없음
+
+            UserPosition selected = deptPositions.get(random.nextInt(deptPositions.size()));
 
             userRepository.save(User.builder()
                     .loginId("staff%03d".formatted(i))  // staff002 ~ staff031
@@ -84,10 +101,11 @@ public class StaffInitializer {
                     .nickname("스태프 %d".formatted(i))
                     .email("staff%03d@mingle.com".formatted(i))
                     .phoneNum("010-0000-%04d".formatted(i))
-                    .imageUrl(null)
+                    .imageUrl("https://api.dicebear.com/7.x/miniavs/svg?seed=" + UUID.randomUUID())
                     .role(UserRole.STAFF)
-                    .status(UserStatus.ONLINE)
                     .department(randomDept)
+                    .position(selected)
+                    .status(UserStatus.ONLINE)
                     .build());
         });
     }

--- a/be/src/main/java/com/example/mingle/global/init/UserPositionSeeder.java
+++ b/be/src/main/java/com/example/mingle/global/init/UserPositionSeeder.java
@@ -1,0 +1,97 @@
+package com.example.mingle.global.init;
+
+import com.example.mingle.domain.user.team.entity.Department;
+import com.example.mingle.domain.user.team.repository.DepartmentRepository;
+import com.example.mingle.domain.user.user.entity.PositionCode;
+import com.example.mingle.domain.user.user.entity.UserPosition;
+import com.example.mingle.domain.user.user.repository.UserPositionRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class UserPositionSeeder {
+
+    private final DepartmentRepository departmentRepository;
+    private final UserPositionRepository userPositionRepository;
+
+    @PostConstruct
+    public void seed() {
+        // 이미 데이터가 있다면 실행하지 않음
+        if (userPositionRepository.count() > 0) return;
+
+        // 부서명 → 직책 목록 매핑
+        Map<String, List<UserPosition>> data = Map.of(
+                // Planning & A&R 부서
+                "Planning & A&R", List.of(
+                        newPosition(PositionCode.CONTENTS_STRATEGIST, "Contents Strategist"),
+                        newPosition(PositionCode.A_AND_R_PLANNER, "A&R Planner"),
+                        newPosition(PositionCode.DEMO_CURATOR, "Demo Curator")
+                ),
+
+                // Creative Studio 부서
+                "Creative Studio", List.of(
+                        newPosition(PositionCode.VISUAL_DESIGNER, "Visual Designer"),
+                        newPosition(PositionCode.MOTION_CREATOR, "Motion Creator"),
+                        newPosition(PositionCode.CREATIVE_EDITOR, "Creative Editor")
+                ),
+
+                // Finance & Legal 부서
+                "Finance & Legal", List.of(
+                        newPosition(PositionCode.FINANCE_PARTNER, "Finance Partner"),
+                        newPosition(PositionCode.LEGAL_ASSISTANT, "Legal Assistant"),
+                        newPosition(PositionCode.CONTRACT_COORDINATOR, "Contract Coordinator")
+                ),
+
+                // Marketing & PR 부서
+                "Marketing & PR", List.of(
+                        newPosition(PositionCode.SOCIAL_MEDIA_MANAGER, "Social Media Manager"),
+                        newPosition(PositionCode.BRAND_DESIGNER, "Brand Designer"),
+                        newPosition(PositionCode.MEDIA_PLANNER, "Media Planner")
+                ),
+
+                // Artist & Manager 부서
+                "Artist & Manager", List.of(
+                        newPosition(PositionCode.ARTIST_COORDINATOR, "Artist Coordinator"),
+                        newPosition(PositionCode.FAN_COMMUNICATION_LEAD, "Fan Communication Lead"),
+                        newPosition(PositionCode.SCHEDULE_MANAGER, "Schedule Manager")
+                ),
+
+                // System Operations 부서
+                "System Operations", List.of(
+                        newPosition(PositionCode.WEBOPS_MANAGER, "WebOps Manager"),
+                        newPosition(PositionCode.INFRA_COORDINATOR, "Infra Coordinator"),
+                        newPosition(PositionCode.TECHOPS_PARTNER, "TechOps Partner")
+                ),
+
+                // Executive 부서
+                "Executive", List.of(
+                        newPosition(PositionCode.STRATEGY_LEAD, "Strategy Lead"),
+                        newPosition(PositionCode.EXECUTIVE_ASSISTANT, "Executive Assistant"),
+                        newPosition(PositionCode.CHIEF_CULTURE_OFFICER, "Chief Culture Officer")
+                )
+        );
+
+        // 각 부서에 매핑된 포지션 저장
+        data.forEach((deptName, positions) -> {
+            Department dept = departmentRepository.findByDepartmentName(deptName)
+                    .orElseThrow(() -> new IllegalStateException(deptName + " 부서를 찾을 수 없습니다."));
+            positions.forEach(pos -> {
+                pos.setDepartment(dept);
+                userPositionRepository.save(pos);
+            });
+        });
+    }
+
+    // 포지션 객체 생성
+    private UserPosition newPosition(PositionCode code, String name) {
+        return UserPosition.builder()
+                .code(code)
+                .name(name)
+                .build();
+    }
+}


### PR DESCRIPTION
## 구현 내용
- `/api/v1/users/me`에서 유저의 `nickname`, `email`, `phoneNum`, `imageUrl`, `position`을 수정할 수 있는 PATCH API 구현
- `position`을 단순 문자열에서 부서 기반의 유연한 구조로 리팩토링
   - 이를 위해 PositionCode, UserPosition 구조 도입