### PR TITLE
[FE/BE/FEAT] 그룹 채팅 - WebSocket 기반 송수신 및 메시지 리스트 구현

### DIFF
--- a/be/src/main/java/com/example/mingle/domain/chat/common/dto/ChatMessagePayload.java
+++ b/be/src/main/java/com/example/mingle/domain/chat/common/dto/ChatMessagePayload.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 /**
  * WebSocket으로 주고받는 채팅 메시지의 구조를 정의한 DTO
  * - 그룹/DM 공용
@@ -38,12 +40,16 @@ public class ChatMessagePayload {
     @NotNull(message = "채팅방 타입(chatType)은 필수입니다.")
     private ChatRoomType roomType;      // GROUP, DIRECT
 
-    public ChatMessagePayload(Long roomId, Long senderId, Long receiverId, String content, MessageFormat format, ChatRoomType roomType) {
+    @NotNull(message = "메시지 생성 시각은 필수입니다.")
+    private LocalDateTime createdAt; // 메시지 생성 시각 (프론트 or 서버 기준)
+
+    public ChatMessagePayload(Long roomId, Long senderId, Long receiverId, String content, MessageFormat format, ChatRoomType roomType, LocalDateTime createdAt) {
         this.roomId = roomId;
         this.senderId = senderId;
         this.receiverId = receiverId;
         this.content = content;
         this.format = format;
         this.roomType = roomType;
+        this.createdAt = createdAt;
     }
 }

--- a/be/src/main/java/com/example/mingle/domain/chat/common/socket/ChatWebSocketHandler.java
+++ b/be/src/main/java/com/example/mingle/domain/chat/common/socket/ChatWebSocketHandler.java
@@ -119,7 +119,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
         }
         Long userId = auth.getUserId();
 
-        // ✅ 1. Presence 메시지 먼저 필터링
+        // 1. Presence 메시지 먼저 필터링
         if ("ping".equals(presencePayload)) {
             presenceService.handlePing(userId);
             return;
@@ -181,7 +181,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
         if (auth != null) {
             presenceService.setStatus(auth.getUserId(), PresenceStatus.OFFLINE);
             presenceService.cancelAwayTimer(auth.getUserId());
-            log.info("🔴 OFFLINE 처리: userId={}", auth.getUserId());
+            log.info("OFFLINE 처리: userId={}", auth.getUserId());
         }
 
         log.info("WebSocket 연결 종료: sessionId = {}", session.getId());

--- a/be/src/main/java/com/example/mingle/domain/chat/group/entity/GroupChatMessage.java
+++ b/be/src/main/java/com/example/mingle/domain/chat/group/entity/GroupChatMessage.java
@@ -2,6 +2,7 @@ package com.example.mingle.domain.chat.group.entity;
 
 import com.example.mingle.domain.chat.common.enums.MessageFormat;
 import com.example.mingle.global.jpa.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -9,6 +10,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
 
 @SuperBuilder
 @AllArgsConstructor
@@ -25,4 +28,7 @@ public class GroupChatMessage extends BaseEntity {
     private MessageFormat format;
 
     private String content;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
 }

--- a/fe/src/features/chat/group/components/GroupChatInput.tsx
+++ b/fe/src/features/chat/group/components/GroupChatInput.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useState } from 'react';
+import { useGroupChat } from '@/features/chat/group/services/useGroupChat';
+
+interface GroupChatInputProps {
+  roomId: number;
+}
+
+export default function GroupChatInput({ roomId }: GroupChatInputProps) {
+  const [content, setContent] = useState('');
+  const { sendGroupMessage } = useGroupChat(roomId);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!content.trim()) return;
+    sendGroupMessage(content);
+    setContent('');
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      style={{ display: 'flex', gap: '8px', padding: '12px' }}
+    >
+      <input
+        type="text"
+        placeholder="메시지를 입력하세요"
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        style={{ flex: 1, padding: '8px' }}
+      />
+      <button type="submit" style={{ padding: '8px 16px' }}>
+        전송
+      </button>
+    </form>
+  );
+}

--- a/fe/src/features/chat/group/components/GroupChatMessageList.tsx
+++ b/fe/src/features/chat/group/components/GroupChatMessageList.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useGroupChat } from '@/features/chat/group/services/useGroupChat';
+import { ChatMessagePayload } from '@/features/chat/common/types/ChatMessagePayload';
+
+interface GroupChatMessageListProps {
+  roomId: number;
+}
+
+export default function GroupChatMessageList({
+  roomId,
+}: GroupChatMessageListProps) {
+  const { messages } = useGroupChat(roomId);
+
+  return (
+    <div
+      style={{
+        padding: '12px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '8px',
+      }}
+    >
+      {messages.map((msg: ChatMessagePayload, idx: number) => (
+        <div
+          key={idx}
+          style={{ background: '#f0f0f0', padding: '8px', borderRadius: '6px' }}
+        >
+          <div style={{ fontSize: '14px', color: '#888' }}>
+            From: {msg.senderId ?? '알 수 없음'}
+          </div>
+          <div>{msg.content}</div>
+          <div style={{ fontSize: '12px', color: '#aaa' }}>
+            {msg.format}
+            {' · '}
+            {msg.createdAt
+              ? new Date(msg.createdAt).toLocaleString('ko-KR', {
+                  year: 'numeric',
+                  month: '2-digit',
+                  day: '2-digit',
+                  hour: '2-digit',
+                  minute: '2-digit',
+                })
+              : '시간 없음'}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/fe/src/features/chat/group/services/useGroupChat.ts
+++ b/fe/src/features/chat/group/services/useGroupChat.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { ChatMessagePayload } from '@/features/chat/common/types/ChatMessagePayload';
+import { ChatRoomType } from '@/features/chat/common/types/ChatRoomType';
+import { connectWebSocket, sendMessage, onMessage } from '@/lib/socket';
+import { MessageFormat } from '@/features/chat/common/types/MessageFormat';
+
+export function useGroupChat(roomId: number) {
+  const [messages, setMessages] = useState<ChatMessagePayload[]>([]);
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (token) {
+      connectWebSocket(token);
+    }
+
+    onMessage((msg: ChatMessagePayload) => {
+      if (msg.chatType === ChatRoomType.GROUP && msg.roomId === roomId) {
+        setMessages((prev) => [...prev, msg]);
+      }
+    });
+  }, [roomId]);
+
+  const sendGroupMessage = (content: string) => {
+    const payload: ChatMessagePayload = {
+      roomId,
+      chatType: ChatRoomType.GROUP,
+      content,
+      format: MessageFormat.TEXT,
+    };
+    sendMessage(payload);
+  };
+
+  return {
+    messages,
+    sendGroupMessage,
+  };
+}

--- a/fe/src/lib/socket.ts
+++ b/fe/src/lib/socket.ts
@@ -1,6 +1,7 @@
 import type { ChatMessagePayload } from '@/features/chat/common/types/ChatMessagePayload';
 
 let socket: WebSocket | null = null;
+const messageHandlers: Array<(msg: ChatMessagePayload) => void> = [];
 
 export function connectWebSocket(token: string) {
   if (socket) socket.close();
@@ -14,7 +15,7 @@ export function connectWebSocket(token: string) {
 
   socket.onmessage = (event) => {
     const data = JSON.parse(event.data);
-    console.log('[받은 메시지]', data);
+    messageHandlers.forEach((handler) => handler(data));
   };
 
   socket.onerror = (err) => {
@@ -32,4 +33,8 @@ export function sendMessage(payload: ChatMessagePayload) {
   } else {
     console.warn('WebSocket이 아직 열리지 않았습니다.');
   }
+}
+
+export function onMessage(handler: (msg: ChatMessagePayload) => void) {
+  messageHandlers.push(handler);
 }


### PR DESCRIPTION
### BE
- `ChatMessagePayload` DTO에 `createdAt` 필드 추가
- `GroupChatMessageServiceImpl.saveAndBroadcast()`에서 DB 저장 + 브로드캐스트 처리
- `ChatWebSocketHandler`에서 메시지 수신 → 그룹/DM 분기 처리 로직 구성

### FE
- `useGroupChat.ts`: WebSocket 수신 메시지 핸들러 작성 및 상태 관리
- `GroupChatMessageList.tsx`: 메시지 목록 UI 렌더링 구현
- 테스트 메시지 송신 로직 연동 (기존 `connect`/`sendMessage` 사용)