### PR TITLE
[FE/FEAT] DM 채팅 - 채팅방 메시지 실시간 송수신 및 receiverId 백엔드 연동 구현

### DIFF
--- a/be/src/main/java/com/example/mingle/domain/chat/dm/controller/ApiV1DmChatController.java
+++ b/be/src/main/java/com/example/mingle/domain/chat/dm/controller/ApiV1DmChatController.java
@@ -45,6 +45,20 @@ public class ApiV1DmChatController {
 
     /**
      * GET
+     * 특정 DM 채팅방의 상대방(receiverId) 조회
+     */
+    @GetMapping("/room/{roomId}/receiver")
+    public Long getReceiverId(
+            @PathVariable Long roomId,
+            @AuthenticationPrincipal SecurityUser loginUser
+    ) {
+        return dmChatRoomService.getReceiverId(roomId, loginUser.getId());
+    }
+
+
+
+    /**
+     * GET
      * 내가 속한 모든 DM 채팅방 요약 정보 반환
      * - 상대 닉네임
      * - 최근 메시지 (content, format, sentAt)
@@ -77,7 +91,7 @@ public class ApiV1DmChatController {
 
 
 
-    // 🟠 [DELETE] 메시지 삭제
+    // [DELETE] 메시지 삭제
     // @DeleteMapping("/messages/{messageId}")
     // public void deleteMessage(@PathVariable Long messageId) { ... } // TODO
 

--- a/be/src/main/java/com/example/mingle/domain/chat/dm/service/DmChatRoomService.java
+++ b/be/src/main/java/com/example/mingle/domain/chat/dm/service/DmChatRoomService.java
@@ -12,4 +12,7 @@ public interface DmChatRoomService {
 
     // 채팅방 목록 요약 정보 조회 (최근 메시지 + 읽지 않은 수)
     List<ChatRoomSummaryResponse> getChatRoomSummaries(Long userId);
+
+    // 특정 채팅방에서 로그인 유저가 아닌 상대방 ID 반환
+    Long getReceiverId(Long roomId, Long requesterId);
 }

--- a/be/src/main/java/com/example/mingle/domain/chat/dm/service/DmChatRoomServiceImpl.java
+++ b/be/src/main/java/com/example/mingle/domain/chat/dm/service/DmChatRoomServiceImpl.java
@@ -7,6 +7,8 @@ import com.example.mingle.domain.chat.dm.repository.DmChatMessageRepository;
 import com.example.mingle.domain.chat.dm.repository.DmChatRoomRepository;
 import com.example.mingle.domain.user.user.entity.User;
 import com.example.mingle.domain.user.user.repository.UserRepository;
+import com.example.mingle.global.exception.ApiException;
+import com.example.mingle.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -75,5 +77,25 @@ public class DmChatRoomServiceImpl implements DmChatRoomService {
                     .sentAt(latestMessage != null ? latestMessage.getCreatedAt() : null)
                     .build();
         }).toList();
+    }
+
+
+
+    /**
+     * 특정 채팅방에서 로그인 유저가 아닌 상대방 ID 반환
+     * - 프론트에서 receiverId 조회할 때 사용
+     */
+    @Override
+    public Long getReceiverId(Long roomId, Long requesterId) {
+        DmChatRoom room = dmChatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND_CHATROOM));
+
+        if (room.getUserAId().equals(requesterId)) {
+            return room.getUserBId();
+        } else if (room.getUserBId().equals(requesterId)) {
+            return room.getUserAId();
+        } else {
+            throw new ApiException(ErrorCode.FORBIDDEN);
+        }
     }
 }

--- a/fe/src/app/(chat-detail)/dm/[roomId]/page.tsx
+++ b/fe/src/app/(chat-detail)/dm/[roomId]/page.tsx
@@ -1,27 +1,63 @@
 'use client';
 
-import { useEffect } from 'react';
-import { connectWebSocket, sendMessage } from '@/lib/socket';
-import { ChatRoomType } from '@/features/chat/common/types/ChatRoomType';
-import { MessageFormat } from '@/features/chat/common/types/MessageFormat';
+import { useEffect, useState } from 'react';
+import { useDmChat } from '@/features/chat/dm/services/useDmChat';
+import { useParams } from 'next/navigation';
+import { ChatMessagePayload } from '@/features/chat/common/types/ChatMessagePayload';
 
-export default function ChatTestPage() {
+export default function DmChatRoomPage() {
+  const { roomId } = useParams();
+  const parsedRoomId = Number(roomId);
+  const [receiverId, setReceiverId] = useState<number | null>(null);
+  const [input, setInput] = useState('');
+
+  // Hook은 항상 조건 없이 호출되어야 함
+  const { messages, sendDmMessage } = useDmChat(parsedRoomId, receiverId);
+
+  // receiverId를 백엔드에서 먼저 받아옴
   useEffect(() => {
-    const token = localStorage.getItem('token');
-    if (token) {
-      connectWebSocket(token);
+    const fetchReceiverId = async () => {
+      try {
+        const res = await fetch(`/api/v1/dm-chat/${parsedRoomId}/receiver-id`);
+        const data = await res.json();
+        setReceiverId(data.receiverId);
+      } catch (error) {
+        console.error('receiverId fetch 실패:', error);
+      }
+    };
 
-      // 테스트 메시지
-      setTimeout(() => {
-        sendMessage({
-          roomId: 1,
-          chatType: ChatRoomType.DM,
-          content: 'WebSocket 테스트',
-          format: MessageFormat.TEXT,
-        });
-      }, 1000);
-    }
-  }, []);
+    fetchReceiverId();
+  }, [parsedRoomId]);
 
-  return <div>WebSocket 연결 테스트 중 (chat-detail)</div>;
+  // receiverId가 없으면 로딩 상태 표시
+  if (receiverId === null) return <div>로딩 중...</div>;
+
+  // receiverId가 아직 null이면 로딩 표시만 렌더링
+  if (receiverId === null) return <div>로딩 중...</div>;
+
+  return (
+    <div style={{ padding: '16px' }}>
+      <div style={{ marginBottom: '12px' }}>
+        {messages.map((msg: ChatMessagePayload, idx: number) => (
+          <div key={idx} style={{ marginBottom: '6px' }}>
+            <strong>{msg.senderId}</strong>: {msg.content}
+          </div>
+        ))}
+      </div>
+      <input
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        style={{ padding: '8px', marginRight: '8px' }}
+      />
+      <button
+        onClick={() => {
+          sendDmMessage(input);
+          setInput('');
+        }}
+        style={{ padding: '8px 16px' }}
+      >
+        전송
+      </button>
+    </div>
+  );
 }

--- a/fe/src/app/(chat-detail)/dm/page.tsx
+++ b/fe/src/app/(chat-detail)/dm/page.tsx
@@ -15,7 +15,7 @@ export default function ChatTestPage() {
       setTimeout(() => {
         sendMessage({
           roomId: 1,
-          chatType: ChatRoomType.DM,
+          chatType: ChatRoomType.DIRECT,
           content: 'WebSocket 테스트',
           format: MessageFormat.TEXT,
           senderId: 1,

--- a/fe/src/features/chat/common/types/ChatRoomType.ts
+++ b/fe/src/features/chat/common/types/ChatRoomType.ts
@@ -1,4 +1,4 @@
 export enum ChatRoomType {
-  DM = 'dm',
+  DIRECT = 'dm',
   GROUP = 'group',
 }

--- a/fe/src/features/chat/dm/components/DmChatInput.tsx
+++ b/fe/src/features/chat/dm/components/DmChatInput.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useState } from 'react';
+
+interface DmChatInputProps {
+  onSend: (content: string) => void;
+}
+
+export default function DmChatInput({ onSend }: DmChatInputProps) {
+  const [content, setContent] = useState('');
+
+  const handleSend = () => {
+    if (content.trim() === '') return;
+    onSend(content);
+    setContent('');
+  };
+
+  return (
+    <div>
+      <input
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') handleSend();
+        }}
+        placeholder="메시지를 입력하세요"
+      />
+      <button onClick={handleSend}>전송</button>
+    </div>
+  );
+}

--- a/fe/src/features/chat/dm/components/DmChatMessageList.tsx
+++ b/fe/src/features/chat/dm/components/DmChatMessageList.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useDmChat } from '@/features/chat/dm/services/useDmChat';
+import { ChatMessagePayload } from '@/features/chat/common/types/ChatMessagePayload';
+
+interface DmChatMessageListProps {
+  roomId: number;
+  receiverId: number;
+}
+
+export default function DmChatMessageList({
+  roomId,
+  receiverId,
+}: DmChatMessageListProps) {
+  const { messages } = useDmChat(roomId, receiverId);
+
+  return (
+    <div
+      style={{
+        padding: '12px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '8px',
+      }}
+    >
+      {messages.map((msg: ChatMessagePayload, idx: number) => (
+        <div
+          key={idx}
+          style={{
+            background: '#fff1f0',
+            padding: '8px',
+            borderRadius: '6px',
+            border: '1px solid #ffccc7',
+          }}
+        >
+          <div style={{ fontSize: '14px', color: '#888' }}>
+            From: {msg.senderId ?? '알 수 없음'}
+          </div>
+          <div>{msg.content}</div>
+          <div style={{ fontSize: '12px', color: '#aaa' }}>{msg.format}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/fe/src/features/chat/dm/services/useDmChat.ts
+++ b/fe/src/features/chat/dm/services/useDmChat.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { connectWebSocket, sendMessage, onMessage } from '@/lib/socket';
+import { ChatMessagePayload } from '@/features/chat/common/types/ChatMessagePayload';
+import { ChatRoomType } from '@/features/chat/common/types/ChatRoomType';
+import { MessageFormat } from '@/features/chat/common/types/MessageFormat';
+
+export function useDmChat(roomId: number, receiverId: number | null) {
+  const [messages, setMessages] = useState<ChatMessagePayload[]>([]);
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (token) {
+      connectWebSocket(token);
+    }
+
+    // 메시지 수신 핸들러 등록
+    onMessage((msg: ChatMessagePayload) => {
+      if (msg.chatType === ChatRoomType.DIRECT && msg.roomId === roomId) {
+        setMessages((prev) => [...prev, msg]);
+      }
+    });
+  }, [roomId]);
+
+  // receiverId가 있을 때만 메시지 전송
+  const sendDmMessage = (content: string) => {
+    if (receiverId === null) return;
+
+    const payload: ChatMessagePayload = {
+      roomId,
+      receiverId,
+      senderId: 1, // 실제 서비스에서는 인증된 유저 ID 사용
+      content,
+      format: MessageFormat.TEXT,
+      chatType: ChatRoomType.DIRECT,
+      createdAt: new Date().toISOString(),
+    };
+    sendMessage(payload);
+  };
+
+  return {
+    messages,
+    sendDmMessage,
+  };
+}


### PR DESCRIPTION
### 프론트엔드
- `useDmChat` 훅 구현 및 `receiverId` 전달 구조 개선
- `DmChatRoomPage`, `DmChatMessageList`에 WebSocket 송수신 적용

### 백엔드
- GET `/api/v1/dm-chat/{roomId}/receiver-id` API 구현
- `DmChatRoomService`: `getReceiverId()` 메서드 추가