### PR TITLE
[FE/FEAT] dm - DM 채팅방 목록 조회 기능 구현

### DIFF
--- a/fe/src/app/(chat-detail)/dm/page.tsx
+++ b/fe/src/app/(chat-detail)/dm/page.tsx
@@ -1,29 +1,12 @@
 'use client';
 
-import { useEffect } from 'react';
-import { connectWebSocket, sendMessage } from '@/lib/socket';
-import { ChatRoomType } from '@/features/chat/common/types/ChatRoomType';
-import { MessageFormat } from '@/features/chat/common/types/MessageFormat';
+import DmChatRoomList from '@/features/chat/dm/components/DmChatRoomList';
 
-export default function ChatTestPage() {
-  useEffect(() => {
-    const token = localStorage.getItem('token');
-    if (token) {
-      connectWebSocket(token);
-
-      // 테스트 메시지
-      setTimeout(() => {
-        sendMessage({
-          roomId: 1,
-          chatType: ChatRoomType.DIRECT,
-          content: 'WebSocket 테스트',
-          format: MessageFormat.TEXT,
-          senderId: 1,
-          createdAt: new Date().toISOString(),
-        });
-      }, 1000);
-    }
-  }, []);
-
-  return <div>WebSocket 연결 테스트 중 (chat-detail)</div>;
+export default function DmChatListPage() {
+  return (
+    <main style={{ padding: '24px' }}>
+      <h1>내 DM 채팅방</h1>
+      <DmChatRoomList />
+    </main>
+  );
 }

--- a/fe/src/features/chat/dm/components/DmChatRoomList.tsx
+++ b/fe/src/features/chat/dm/components/DmChatRoomList.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useDmChatRoomList } from '@/features/chat/dm/services/useDmChatRoomList';
+import { ChatRoomSummary } from '@/features/chat/dm/types/ChatRoomSummary';
+import { useRouter } from 'next/navigation';
+
+export default function DmChatRoomList() {
+  const { rooms } = useDmChatRoomList();
+  const router = useRouter();
+
+  return (
+    <div style={{ padding: '16px' }}>
+      <h2>DM 채팅방 목록</h2>
+      {rooms.length === 0 ? (
+        <div>채팅방이 없습니다.</div>
+      ) : (
+        <ul style={{ listStyle: 'none', padding: 0 }}>
+          {rooms.map((room: ChatRoomSummary, idx: number) => (
+            <li
+              key={idx}
+              onClick={() => router.push(`/chat-detail/dm/${room.roomId}`)} // router.push 사용으로 이동
+              style={{
+                padding: '12px',
+                marginBottom: '12px',
+                border: '1px solid #ccc',
+                borderRadius: '8px',
+                cursor: 'pointer',
+                background: room.unreadCount > 0 ? '#fff7e6' : '#f9f9f9', // 안 읽은 메시지 색상 강조
+              }}
+            >
+              <div style={{ fontWeight: 'bold' }}>{room.opponentNickname}</div>
+              <div>
+                {/* 메시지 형식 구분 */}
+                {room.format === 'ARCHIVE' ? '[자료]' : room.previewMessage}
+                {' | '}
+                {room.sentAt?.slice(0, 16).replace('T', ' ')}
+              </div>
+              {/* 안 읽은 메시지 수 강조 */}
+              {room.unreadCount > 0 && (
+                <div style={{ color: 'red' }}>
+                  안 읽은 메시지 {room.unreadCount}개
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/fe/src/features/chat/dm/services/useDmChatRoomList.ts
+++ b/fe/src/features/chat/dm/services/useDmChatRoomList.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+import { apiClient } from '@/lib/api/apiClient';
+import { ChatRoomSummary } from '../types/ChatRoomSummary';
+
+export function useDmChatRoomList() {
+  const [rooms, setRooms] = useState<ChatRoomSummary[]>([]);
+
+  useEffect(() => {
+    const fetchRooms = async () => {
+      const data = await apiClient<ChatRoomSummary[]>(
+        '/api/v1/dm-chat/summary'
+      );
+      setRooms(data);
+    };
+    fetchRooms();
+  }, []);
+
+  return { rooms };
+}

--- a/fe/src/features/chat/dm/types/ChatRoomSummary.ts
+++ b/fe/src/features/chat/dm/types/ChatRoomSummary.ts
@@ -1,0 +1,10 @@
+import { MessageFormat } from '@/features/chat/common/types/MessageFormat';
+
+export interface ChatRoomSummary {
+  roomId: number; // 채팅방 ID
+  opponentNickname: string; // 상대방 닉네임
+  previewMessage: string; // 최근 메시지 내용
+  format: MessageFormat; // 메시지 형식 (TEXT, ARCHIVE 등)
+  unreadCount: number; // 읽지 않은 메시지 수
+  sentAt: string; // 메시지 전송 시각 (ISO 문자열)
+}


### PR DESCRIPTION
💜 어떤 기능인가요?
- 로그인한 유저가 참여 중인 DM 채팅방 목록을 불러옵니다.
- 각 방에 대해:
   - 상대방 닉네임
   - 마지막 메시지 (형식이 ARCHIVE인 경우 [자료] 표시)
   - 전송 시각
   - 읽지 않은 메시지 수
를 함께 보여줍니다.

🤔 왜 필요한가요?
- 채팅 목록 진입 시 유저가 어떤 DM 채팅방에 참여 중인지 한눈에 확인 가능하게 하기 위해
- 리스트에서 클릭 시 해당 채팅방 상세로 이동할 수 있도록 연결도 함께 구현

💡 참고 사항
- GET `/api/v1/dm-chat/summary API` 연동
- `ChatRoomSummary` 타입 기반 구현
- 추후 그룹 채팅 목록과 동일한 컴포넌트 구조 재사용 고려 필요

