### PR TITLE
[FE,BE/FEAT] 그룹 채팅방 목록 조회 - API 연동 및 UI 구현 + [BE/FEAT] 그룹 채팅방 목록 조회 -…

### DIFF
--- a/be/src/main/java/com/example/mingle/domain/chat/dm/controller/ApiV1DmChatController.java
+++ b/be/src/main/java/com/example/mingle/domain/chat/dm/controller/ApiV1DmChatController.java
@@ -1,11 +1,9 @@
 package com.example.mingle.domain.chat.dm.controller;
 
-import com.example.mingle.domain.chat.common.enums.MessageFormat;
-import com.example.mingle.domain.chat.dm.dto.ChatRoomSummaryResponse;
+import com.example.mingle.domain.chat.dm.dto.DmChatRoomSummaryResponse;
 import com.example.mingle.domain.chat.dm.dto.DmChatMessageResponse;
 import com.example.mingle.domain.chat.dm.dto.DmChatRoomCreateRequest;
 import com.example.mingle.domain.chat.dm.dto.DmChatRoomResponse;
-import com.example.mingle.domain.chat.dm.entity.DmChatMessage;
 import com.example.mingle.domain.chat.dm.entity.DmChatRoom;
 import com.example.mingle.domain.chat.dm.repository.DmChatMessageRepository;
 import com.example.mingle.domain.chat.dm.service.DmChatMessageService;
@@ -65,7 +63,7 @@ public class ApiV1DmChatController {
      * - 읽지 않은 메시지 수
      */
     @GetMapping("/summary")
-    public List<ChatRoomSummaryResponse> getChatRoomSummaries(
+    public List<DmChatRoomSummaryResponse> getChatRoomSummaries(
             @AuthenticationPrincipal SecurityUser loginUser
     ) {
         return dmChatRoomService.getChatRoomSummaries(loginUser.getId());

--- a/be/src/main/java/com/example/mingle/domain/chat/dm/dto/DmChatRoomSummaryResponse.java
+++ b/be/src/main/java/com/example/mingle/domain/chat/dm/dto/DmChatRoomSummaryResponse.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
  * - 채팅방 목록에 표시될 정보 (최근 메시지, 미확인 수 등)
  */
 @Builder
-public record ChatRoomSummaryResponse(
+public record DmChatRoomSummaryResponse(
         Long roomId,               // 채팅방 ID
         String opponentNickname,   // 상대방 닉네임
         String previewMessage,     // 가장 최근 메시지 본문

--- a/be/src/main/java/com/example/mingle/domain/chat/dm/service/DmChatRoomService.java
+++ b/be/src/main/java/com/example/mingle/domain/chat/dm/service/DmChatRoomService.java
@@ -1,6 +1,6 @@
 package com.example.mingle.domain.chat.dm.service;
 
-import com.example.mingle.domain.chat.dm.dto.ChatRoomSummaryResponse;
+import com.example.mingle.domain.chat.dm.dto.DmChatRoomSummaryResponse;
 import com.example.mingle.domain.chat.dm.entity.DmChatRoom;
 
 import java.util.List;
@@ -11,7 +11,7 @@ public interface DmChatRoomService {
     DmChatRoom findOrCreateRoom(Long senderId, Long receiverId);
 
     // 채팅방 목록 요약 정보 조회 (최근 메시지 + 읽지 않은 수)
-    List<ChatRoomSummaryResponse> getChatRoomSummaries(Long userId);
+    List<DmChatRoomSummaryResponse> getChatRoomSummaries(Long userId);
 
     // 특정 채팅방에서 로그인 유저가 아닌 상대방 ID 반환
     Long getReceiverId(Long roomId, Long requesterId);

--- a/be/src/main/java/com/example/mingle/domain/chat/dm/service/DmChatRoomServiceImpl.java
+++ b/be/src/main/java/com/example/mingle/domain/chat/dm/service/DmChatRoomServiceImpl.java
@@ -1,6 +1,6 @@
 package com.example.mingle.domain.chat.dm.service;
 
-import com.example.mingle.domain.chat.dm.dto.ChatRoomSummaryResponse;
+import com.example.mingle.domain.chat.dm.dto.DmChatRoomSummaryResponse;
 import com.example.mingle.domain.chat.dm.entity.DmChatMessage;
 import com.example.mingle.domain.chat.dm.entity.DmChatRoom;
 import com.example.mingle.domain.chat.dm.repository.DmChatMessageRepository;
@@ -52,7 +52,7 @@ public class DmChatRoomServiceImpl implements DmChatRoomService {
      * - 최근 메시지, 읽지 않은 수, 상대방 닉네임 포함
      */
     @Override
-    public List<ChatRoomSummaryResponse> getChatRoomSummaries(Long userId) {
+    public List<DmChatRoomSummaryResponse> getChatRoomSummaries(Long userId) {
         List<DmChatRoom> myRooms = dmChatRoomRepository.findByUserAIdOrUserBId(userId, userId); // 내가 속한 채팅방 전체 조회
 
         return myRooms.stream().map(room -> {
@@ -68,7 +68,7 @@ public class DmChatRoomServiceImpl implements DmChatRoomService {
             int unreadCount = dmChatMessageRepository
                     .countByDmRoomIdAndReceiverIdAndIsReadFalse(room.getId(), userId);
 
-            return ChatRoomSummaryResponse.builder()
+            return DmChatRoomSummaryResponse.builder()
                     .roomId(room.getId())
                     .opponentNickname(opponent != null ? opponent.getNickname() : "알 수 없음")
                     .previewMessage(latestMessage != null ? latestMessage.getContent() : "(메시지 없음)")

--- a/be/src/main/java/com/example/mingle/domain/chat/group/controller/ApiV1GroupChatController.java
+++ b/be/src/main/java/com/example/mingle/domain/chat/group/controller/ApiV1GroupChatController.java
@@ -2,6 +2,7 @@ package com.example.mingle.domain.chat.group.controller;
 
 import com.example.mingle.domain.chat.group.dto.GroupChatRoomCreateRequest;
 import com.example.mingle.domain.chat.group.dto.GroupChatRoomResponse;
+import com.example.mingle.domain.chat.group.dto.GroupChatRoomSummaryResponse;
 import com.example.mingle.domain.chat.group.dto.GroupChatMessageResponse;
 import com.example.mingle.domain.chat.common.enums.ChatScope;
 import com.example.mingle.domain.chat.group.service.GroupChatRoomService;
@@ -50,6 +51,22 @@ public class ApiV1GroupChatController {
             @AuthenticationPrincipal SecurityUser loginUser
     ) {
         return groupChatRoomService.findMyRooms(loginUser.getId(), scope);
+    }
+
+
+
+    /**
+     * GET
+     * 채팅방 요약 목록 조회 (자료방/채팅방 구분된 요약 UI용)
+     * - 프론트: 사이드바에서 채팅방 리스트 간략히 띄우는 용도
+     * - 반환 형태: GroupChatRoomSummaryResponse (roomId, name, previewMessage 등)
+     */
+    @GetMapping("/summaries")
+    public List<GroupChatRoomSummaryResponse> getGroupChatRoomSummaries(
+            @RequestParam ChatScope scope,
+            @AuthenticationPrincipal SecurityUser loginUser
+    ) {
+        return groupChatRoomService.getGroupChatRoomSummaries(loginUser.getId(), scope);
     }
 
 

--- a/be/src/main/java/com/example/mingle/domain/chat/group/dto/GroupChatRoomSummaryResponse.java
+++ b/be/src/main/java/com/example/mingle/domain/chat/group/dto/GroupChatRoomSummaryResponse.java
@@ -1,0 +1,35 @@
+package com.example.mingle.domain.chat.group.dto;
+
+import com.example.mingle.domain.chat.common.enums.MessageFormat;
+import com.example.mingle.domain.chat.common.enums.RoomType;
+import com.example.mingle.domain.chat.group.entity.GroupChatRoom;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+/**
+ * Group 채팅방 요약 정보 DTO
+ * - 채팅방 목록에 표시될 정보 (최근 메시지, 미확인 수 등)
+ */
+@Builder
+public record GroupChatRoomSummaryResponse(
+    Long roomId,             // 채팅방 ID
+    String name,             // 부서명 또는 프로젝트명
+    RoomType roomType,
+    String previewMessage,   // 가장 최근 메시지 본문
+    MessageFormat format,    // 메시지 포맷 (TEXT, IMAGE 등)
+    int unreadCount,         // 읽지 않은 메시지 수
+    LocalDateTime sentAt     // 가장 최근 메시지 시간
+){
+    public static GroupChatRoomSummaryResponse from(GroupChatRoom room) {
+        return new GroupChatRoomSummaryResponse(
+                room.getId(),
+                room.getName(),
+                room.getRoomType(),
+                "",         // 추후 채팅 내용 연결 예정
+                MessageFormat.TEXT,      // 메시지 형식
+                0,                       // 안 읽은 메시지 수
+                null                     // 최근 메시지 시간
+        );
+    }
+}

--- a/be/src/main/java/com/example/mingle/domain/chat/group/service/GroupChatRoomService.java
+++ b/be/src/main/java/com/example/mingle/domain/chat/group/service/GroupChatRoomService.java
@@ -3,6 +3,7 @@ package com.example.mingle.domain.chat.group.service;
 import com.example.mingle.domain.chat.common.enums.ChatScope;
 import com.example.mingle.domain.chat.group.dto.GroupChatRoomCreateRequest;
 import com.example.mingle.domain.chat.group.dto.GroupChatRoomResponse;
+import com.example.mingle.domain.chat.group.dto.GroupChatRoomSummaryResponse;
 
 import java.util.List;
 
@@ -22,4 +23,11 @@ public interface GroupChatRoomService {
 
     // 채팅방 이름 검색
     List<GroupChatRoomResponse> searchRoomsByKeyword(String keyword);
+
+    /**
+     * 채팅방 요약 목록 조회 (프론트 전용)
+     * - 기본 채팅 목록 화면에 보여줄 요약 정보 (이름, 미리보기 메시지, 안 읽은 메시지 수 등)
+     * - scope(DEPARTMENT 또는 PROJECT)에 따라 부서 또는 프로젝트 채팅방을 구분해서 조회
+     */
+    List<GroupChatRoomSummaryResponse> getGroupChatRoomSummaries(Long userId, ChatScope scope);
 }

--- a/fe/src/app/(chat-detail)/group/page.tsx
+++ b/fe/src/app/(chat-detail)/group/page.tsx
@@ -1,0 +1,5 @@
+import GroupChatRoomList from '@/features/chat/group/components/GroupChatRoomList';
+
+export default function GroupChatRoomListPage() {
+  return <GroupChatRoomList />;
+}

--- a/fe/src/features/chat/dm/components/DmChatRoomList.tsx
+++ b/fe/src/features/chat/dm/components/DmChatRoomList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useDmChatRoomList } from '@/features/chat/dm/services/useDmChatRoomList';
-import { ChatRoomSummary } from '@/features/chat/dm/types/ChatRoomSummary';
+import { DmChatRoomSummary } from '@/features/chat/dm/types/DmChatRoomSummary';
 import { useRouter } from 'next/navigation';
 
 export default function DmChatRoomList() {
@@ -15,7 +15,7 @@ export default function DmChatRoomList() {
         <div>채팅방이 없습니다.</div>
       ) : (
         <ul style={{ listStyle: 'none', padding: 0 }}>
-          {rooms.map((room: ChatRoomSummary, idx: number) => (
+          {rooms.map((room: DmChatRoomSummary, idx: number) => (
             <li
               key={idx}
               onClick={() => router.push(`/chat-detail/dm/${room.roomId}`)} // router.push 사용으로 이동

--- a/fe/src/features/chat/dm/services/useDmChatRoomList.ts
+++ b/fe/src/features/chat/dm/services/useDmChatRoomList.ts
@@ -1,13 +1,13 @@
 import { useEffect, useState } from 'react';
 import { apiClient } from '@/lib/api/apiClient';
-import { ChatRoomSummary } from '../types/ChatRoomSummary';
+import { DmChatRoomSummary } from '../types/DmChatRoomSummary';
 
 export function useDmChatRoomList() {
-  const [rooms, setRooms] = useState<ChatRoomSummary[]>([]);
+  const [rooms, setRooms] = useState<DmChatRoomSummary[]>([]);
 
   useEffect(() => {
     const fetchRooms = async () => {
-      const data = await apiClient<ChatRoomSummary[]>(
+      const data = await apiClient<DmChatRoomSummary[]>(
         '/api/v1/dm-chat/summary'
       );
       setRooms(data);

--- a/fe/src/features/chat/dm/types/DmChatRoomSummary.ts
+++ b/fe/src/features/chat/dm/types/DmChatRoomSummary.ts
@@ -1,6 +1,6 @@
 import { MessageFormat } from '@/features/chat/common/types/MessageFormat';
 
-export interface ChatRoomSummary {
+export interface DmChatRoomSummary {
   roomId: number; // 채팅방 ID
   opponentNickname: string; // 상대방 닉네임
   previewMessage: string; // 최근 메시지 내용

--- a/fe/src/features/chat/group/components/GroupChatRoomList.tsx
+++ b/fe/src/features/chat/group/components/GroupChatRoomList.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useGroupChatRoomList } from '@/features/chat/group/services/useGroupChatRoomList';
+import { GroupChatRoomSummary } from '@/features/chat/group/types/GroupChatRoomSummary';
+import Link from 'next/link';
+
+// 그룹 채팅방 목록을 보여주는 UI 컴포넌트
+// - 서버에서 요약 목록 데이터를 받아와 리스트로 출력
+export default function GroupChatRoomList() {
+  // 그룹 채팅방 목록 상태 가져오기
+  const { rooms } = useGroupChatRoomList();
+
+  return (
+    <div style={{ padding: '16px' }}>
+      <h2>그룹 채팅방 목록</h2>
+
+      {/* 채팅방이 없을 경우 메시지 표시 */}
+      {rooms.length === 0 ? (
+        <div>채팅방이 없습니다.</div>
+      ) : (
+        <ul style={{ listStyle: 'none', padding: 0 }}>
+          {/* 채팅방 목록 map으로 반복 출력 */}
+          {rooms.map((room: GroupChatRoomSummary) => (
+            <li
+              key={room.roomId}
+              style={{
+                padding: '12px',
+                borderBottom: '1px solid #eee',
+              }}
+            >
+              {/* 채팅방 링크 클릭 시 상세 페이지로 이동 */}
+              <Link href={`/chat-detail/group/${room.roomId}`}>
+                <div style={{ fontWeight: 'bold' }}>{room.name}</div>
+
+                {/* 메시지 형식이 ARCHIVE면 [자료] 라벨 붙이기 */}
+                <div>
+                  {room.format === 'ARCHIVE' ? '[자료]' : room.previewMessage}
+                </div>
+
+                {/* 메시지 전송 시각과 안읽은 메시지 개수 표시 */}
+                <div style={{ fontSize: '12px', color: '#888' }}>
+                  {room.sentAt ? room.sentAt : '시간 없음'} / {room.unreadCount}
+                  개 안읽음
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/fe/src/features/chat/group/services/useGroupChatRoomList.ts
+++ b/fe/src/features/chat/group/services/useGroupChatRoomList.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { apiClient } from '@/lib/api/apiClient';
+import { GroupChatRoomSummary } from '@/features/chat/group/types/GroupChatRoomSummary';
+
+export function useGroupChatRoomList() {
+  // 그룹 채팅방 목록 상태 정의
+  const [rooms, setRooms] = useState<GroupChatRoomSummary[]>([]);
+
+  useEffect(() => {
+    // 그룹 채팅방 목록을 백엔드에서 불러오는 함수
+    const fetchRooms = async () => {
+      try {
+        // GET /api/v1/group-chats/rooms 호출
+        const res = await apiClient<GroupChatRoomSummary[]>(
+          '/api/v1/group-chats/rooms'
+        );
+
+        // 성공적으로 응답 받았을 경우 상태 업데이트
+        setRooms(res);
+      } catch (error) {
+        // 실패 시 에러 콘솔 출력
+        console.error('그룹 채팅방 목록 불러오기 실패:', error);
+      }
+    };
+
+    // 컴포넌트가 마운트될 때 그룹 채팅방 목록 불러오기 실행
+    fetchRooms();
+  }, []);
+
+  // 그룹 채팅방 목록 상태 반환
+  return { rooms };
+}

--- a/fe/src/features/chat/group/types/GroupChatRoomSummary.ts
+++ b/fe/src/features/chat/group/types/GroupChatRoomSummary.ts
@@ -1,0 +1,10 @@
+import { MessageFormat } from '@/features/chat/common/types/MessageFormat';
+
+export interface GroupChatRoomSummary {
+  roomId: number; // 채팅방 ID
+  opponentNickname: string; // 상대방 닉네임
+  previewMessage: string; // 최근 메시지 내용
+  format: MessageFormat; // 메시지 형식 (TEXT, ARCHIVE 등)
+  unreadCount: number; // 읽지 않은 메시지 수
+  sentAt: string; // 메시지 전송 시각 (ISO 문자열)
+}


### PR DESCRIPTION
### FE
- 프론트엔드 타입 정의 (`GroupChatRoomSummary`)
- `useGroupChatRoomList.ts` 훅 추가: API 호출 및 상태 관리
- `GroupChatRoomList.tsx` 컴포넌트 구현: 그룹 채팅방 목록 UI 표시 및 링크 연결
- 상세 페이지 링크(`/chat-detail/group/[roomId]`) 연결만 수행 (페이지 구현은 다음 이슈에서 처리 예정)

### BE
- GroupChatRoomSummaryResponse DTO 생성: 최근 메시지, 읽지 않은 메시지 수 포함
- GroupChatRoomServiceImpl에 getGroupChatRoomSummaries() 메서드 추가
- 중복 로직 제거를 위한 findRoomsByScope() 내부 메서드 분리
- ApiV1GroupChatController에 GET /api/v1/group-chats/rooms API 추가
- 기존 findMyRooms() 메서드와 중복되는 부분 정리 및 목적 분리

### 확인 방법
- `/chat-detail/group`에서 그룹 채팅방 목록 확인 가능
- 백엔드 /api/v1/group-chats/rooms API 정상 동작
- 채팅방 이름, 미리보기 메시지, 읽지 않은 수, 최근 시간 UI 확인