### PR TITLE
[BE/FEAT] 그룹 채팅방 요약 응답에 미리보기 메시지, 미확인 수, 전송 시간 연동

### DIFF
--- a/be/src/main/java/com/example/mingle/domain/chat/group/entity/GroupChatMessage.java
+++ b/be/src/main/java/com/example/mingle/domain/chat/group/entity/GroupChatMessage.java
@@ -31,4 +31,8 @@ public class GroupChatMessage extends BaseEntity {
 
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
+
+    @Column(name = "is_read")
+    private boolean isRead;
+
 }

--- a/be/src/main/java/com/example/mingle/domain/chat/group/repository/GroupChatMessageRepository.java
+++ b/be/src/main/java/com/example/mingle/domain/chat/group/repository/GroupChatMessageRepository.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface GroupChatMessageRepository extends JpaRepository<GroupChatMessage, Long> {
@@ -19,4 +20,10 @@ public interface GroupChatMessageRepository extends JpaRepository<GroupChatMessa
             Long chatRoomId,
             LocalDateTime cursor
     );
+
+    // 최근 메시지 1개 조회
+    Optional<GroupChatMessage> findTopByChatRoomIdOrderByCreatedAtDesc(Long chatRoomId);
+
+    // 안읽은 메시지 수 조회 (보낸 사람 제외)
+    int countByChatRoomIdAndSenderIdNotAndIsReadFalse(Long chatRoomId, Long senderId);
 }

--- a/be/src/main/java/com/example/mingle/domain/chat/group/service/GroupChatRoomService.java
+++ b/be/src/main/java/com/example/mingle/domain/chat/group/service/GroupChatRoomService.java
@@ -26,7 +26,7 @@ public interface GroupChatRoomService {
 
     /**
      * 채팅방 요약 목록 조회 (프론트 전용)
-     * - 기본 채팅 목록 화면에 보여줄 요약 정보 (이름, 미리보기 메시지, 안 읽은 메시지 수 등)
+     * - 기본 채팅 목록 화면에 보여줄 요약 정보 (이름, 최근 메시지, 미리보기 메시지, 안 읽은 메시지 수,등)
      * - scope(DEPARTMENT 또는 PROJECT)에 따라 부서 또는 프로젝트 채팅방을 구분해서 조회
      */
     List<GroupChatRoomSummaryResponse> getGroupChatRoomSummaries(Long userId, ChatScope scope);

--- a/fe/src/features/chat/group/components/GroupChatRoomList.tsx
+++ b/fe/src/features/chat/group/components/GroupChatRoomList.tsx
@@ -2,13 +2,25 @@
 
 import { useGroupChatRoomList } from '@/features/chat/group/services/useGroupChatRoomList';
 import { GroupChatRoomSummary } from '@/features/chat/group/types/GroupChatRoomSummary';
+import { ChatScope } from '@/features/chat/common/types/ChatScope';
 import Link from 'next/link';
+
+// 시간 포맷팅 함수 (오전/오후 HH:MM 형태)
+function formatTime(isoTime: string | null): string {
+  if (!isoTime) return '시간 없음';
+  const date = new Date(isoTime);
+  const hours = date.getHours();
+  const minutes = date.getMinutes().toString().padStart(2, '0');
+  const isAM = hours < 12;
+  const displayHour = hours % 12 || 12;
+  return `${isAM ? '오전' : '오후'} ${displayHour}:${minutes}`;
+}
 
 // 그룹 채팅방 목록을 보여주는 UI 컴포넌트
 // - 서버에서 요약 목록 데이터를 받아와 리스트로 출력
 export default function GroupChatRoomList() {
   // 그룹 채팅방 목록 상태 가져오기
-  const { rooms } = useGroupChatRoomList();
+  const { rooms } = useGroupChatRoomList({ scope: ChatScope.DEPARTMENT });
 
   return (
     <div style={{ padding: '16px' }}>
@@ -37,10 +49,9 @@ export default function GroupChatRoomList() {
                   {room.format === 'ARCHIVE' ? '[자료]' : room.previewMessage}
                 </div>
 
-                {/* 메시지 전송 시각과 안읽은 메시지 개수 표시 */}
+                {/* 메시지 전송 시각과 안읽은 메시지 개수 표시(시간 포맷팅 적용) */}
                 <div style={{ fontSize: '12px', color: '#888' }}>
-                  {room.sentAt ? room.sentAt : '시간 없음'} / {room.unreadCount}
-                  개 안읽음
+                  {formatTime(room.sentAt)} / {room.unreadCount}개 안읽음
                 </div>
               </Link>
             </li>

--- a/fe/src/features/chat/group/services/useGroupChatRoomList.ts
+++ b/fe/src/features/chat/group/services/useGroupChatRoomList.ts
@@ -3,8 +3,13 @@
 import { useEffect, useState } from 'react';
 import { apiClient } from '@/lib/api/apiClient';
 import { GroupChatRoomSummary } from '@/features/chat/group/types/GroupChatRoomSummary';
+import { ChatScope } from '@/features/chat/common/types/ChatScope';
 
-export function useGroupChatRoomList() {
+interface UseGroupChatRoomListOptions {
+  scope: ChatScope; // scope를 동적으로 받을 수 있도록 수정
+}
+
+export function useGroupChatRoomList({ scope }: UseGroupChatRoomListOptions) {
   // 그룹 채팅방 목록 상태 정의
   const [rooms, setRooms] = useState<GroupChatRoomSummary[]>([]);
 
@@ -14,8 +19,9 @@ export function useGroupChatRoomList() {
       try {
         // GET /api/v1/group-chats/rooms 호출
         const res = await apiClient<GroupChatRoomSummary[]>(
-          '/api/v1/group-chats/rooms'
+          '/api/v1/group-chats/rooms?scope=${scope}'
         );
+        console.log('그룹 채팅방 요약 목록:', res);
 
         // 성공적으로 응답 받았을 경우 상태 업데이트
         setRooms(res);
@@ -27,7 +33,7 @@ export function useGroupChatRoomList() {
 
     // 컴포넌트가 마운트될 때 그룹 채팅방 목록 불러오기 실행
     fetchRooms();
-  }, []);
+  }, [scope]);
 
   // 그룹 채팅방 목록 상태 반환
   return { rooms };


### PR DESCRIPTION
## 📌 구현 내용

- GroupChatRoomSummaryResponse DTO에 다음 항목 연동:
  - previewMessage (최근 메시지)
  - unreadCount (읽지 않은 메시지 수)
  - sentAt (마지막 메시지 전송 시간)

- GroupChatMessageRepository에서 관련 JPQL 메서드 정의 및 연동
- GroupChatRoomServiceImpl 내부 로직 수정: 채팅방별 최신 메시지 및 미확인 수 처리

- 프론트엔드 useGroupChatRoomList 훅 수정
  - scope 파라미터를 기반으로 목록 API 호출 가능하도록 수정
  - 시간 포맷팅 (오전/오후 HH:MM) 적용
  - `[자료]` 라벨 표시 및 null-safe 전송시간 표시 추가

## ✅ 확인 사항
- [x] 백엔드에서 scope 기준으로 올바른 채팅방 목록과 메시지 정보 응답
- [x] 프론트엔드 UI에 최신 메시지 / 시간 / 안읽은 수 정상 출력됨
- [x] 예외 상황에서도 UI가 깨지지 않도록 처리됨
