### PR TITLE
[FE/FEAT] Group 채팅방 목록 조회 탭 - UI 구성 및 전환 기능

### DIFF
--- a/fe/src/features/chat/group/components/GroupChatRoomList.tsx
+++ b/fe/src/features/chat/group/components/GroupChatRoomList.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { useGroupChatRoomList } from '@/features/chat/group/services/useGroupChatRoomList';
 import { GroupChatRoomSummary } from '@/features/chat/group/types/GroupChatRoomSummary';
 import { ChatScope } from '@/features/chat/common/types/ChatScope';
@@ -19,12 +20,45 @@ function formatTime(isoTime: string | null): string {
 // 그룹 채팅방 목록을 보여주는 UI 컴포넌트
 // - 서버에서 요약 목록 데이터를 받아와 리스트로 출력
 export default function GroupChatRoomList() {
-  // 그룹 채팅방 목록 상태 가져오기
-  const { rooms } = useGroupChatRoomList({ scope: ChatScope.DEPARTMENT });
+  // 현재 선택된 scope (부서/프로젝트)
+  const [scope, setScope] = useState<ChatScope>(ChatScope.DEPARTMENT);
+
+  // 선택된 scope에 따라 API 호출
+  const { rooms } = useGroupChatRoomList({ scope });
 
   return (
     <div style={{ padding: '16px' }}>
       <h2>그룹 채팅방 목록</h2>
+
+      {/* scope 전환 탭 버튼 */}
+      <div style={{ marginBottom: '16px', display: 'flex', gap: '8px' }}>
+        <button
+          onClick={() => setScope(ChatScope.DEPARTMENT)}
+          style={{
+            padding: '6px 12px',
+            background: scope === ChatScope.DEPARTMENT ? '#0070f3' : '#eee',
+            color: scope === ChatScope.DEPARTMENT ? 'white' : '#333',
+            border: 'none',
+            borderRadius: '4px',
+            cursor: 'pointer',
+          }}
+        >
+          부서 채팅방
+        </button>
+        <button
+          onClick={() => setScope(ChatScope.PROJECT)}
+          style={{
+            padding: '6px 12px',
+            background: scope === ChatScope.PROJECT ? '#0070f3' : '#eee',
+            color: scope === ChatScope.PROJECT ? 'white' : '#333',
+            border: 'none',
+            borderRadius: '4px',
+            cursor: 'pointer',
+          }}
+        >
+          프로젝트 채팅방
+        </button>
+      </div>
 
       {/* 채팅방이 없을 경우 메시지 표시 */}
       {rooms.length === 0 ? (
@@ -41,7 +75,7 @@ export default function GroupChatRoomList() {
               }}
             >
               {/* 채팅방 링크 클릭 시 상세 페이지로 이동 */}
-              <Link href={`/chat-detail/group/${room.roomId}`}>
+              <Link href={`/group/${room.roomId}`}>
                 <div style={{ fontWeight: 'bold' }}>{room.name}</div>
 
                 {/* 메시지 형식이 ARCHIVE면 [자료] 라벨 붙이기 */}


### PR DESCRIPTION
💜 어떤 기능인가요?
- 부서/프로젝트 그룹 채팅방을 `scope` 기준으로 구분해서 목록을 보여주는 상단 탭 UI를 구성했습니다.
- 사용자가 탭을 클릭할 때마다 API를 통해 채팅방 목록이 동적으로 변경됩니다.

🛠 어떤 작업을 했나요?
- `ChatScope` 상태를 관리하는 `useState` 훅 추가
- `scope`를 기반으로 데이터를 요청하는 `useGroupChatRoomList` 훅 내부 로직 개선
- `GroupChatRoomList.tsx`에 탭 전환 UI 및 스타일 적용
- `scope` 변경 시 채팅방 목록이 실시간으로 반영되도록 연동

✅ 완료 조건
- 상단 탭 UI 2개 (부서 / 프로젝트) 렌더링
- 탭 클릭 시 상태 전환 및 목록 API 호출
- 선택된 탭 시각적 강조 스타일 적용
- 채팅방 미존재 시 예외 메시지 출력