### PR TITLE
[FE/FEAT] 그룹 채팅 상세 진입 시 채팅방 정보 및 메시지 출력 UI 구성

### DIFF
--- a/fe/src/app/(chat-detail)/group/[roomId]/page.tsx
+++ b/fe/src/app/(chat-detail)/group/[roomId]/page.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { fetchGroupChatRoomInfo } from '@/features/chat/group/services/fetchGroupChatRoomInfo';
+import { GroupChatRoom } from '@/features/chat/group/types/GroupChatRoom';
+import GroupChatRoomHeader from '@/features/chat/group/components/GroupChatRoomHeader';
+import GroupChatMessageList from '@/features/chat/group/components/GroupChatMessageList';
+import GroupChatInput from '@/features/chat/group/components/GroupChatInput';
+
+export default function GroupChatDetailPage() {
+  // [1] URL에서 roomId 파라미터 추출
+  const params = useParams();
+  const roomId = Number(params.roomId);
+
+  // [2] 채팅방 정보 상태 정의
+  const [roomInfo, setRoomInfo] = useState<GroupChatRoom | null>(null);
+
+  // [3] 컴포넌트 마운트 시 roomId로 채팅방 정보 요청
+  useEffect(() => {
+    const fetchRoom = async () => {
+      try {
+        const data = await fetchGroupChatRoomInfo(roomId);
+        setRoomInfo(data);
+      } catch (error) {
+        console.error('채팅방 정보 불러오기 실패:', error);
+      }
+    };
+
+    fetchRoom();
+  }, [roomId]);
+
+  // [4] 로딩 처리 (데이터 없으면 렌더링 지연)
+  if (!roomInfo) {
+    return <div style={{ padding: '24px' }}>채팅방 정보를 불러오는 중...</div>;
+  }
+
+  // [5] 채팅방 상세 UI 렌더링
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+      {/* 채팅방 상단 정보 (이름, 유형 등) */}
+      <GroupChatRoomHeader room={roomInfo} />
+
+      {/* 채팅 메시지 리스트 (스크롤 가능) */}
+      <div style={{ flex: 1, overflowY: 'auto' }}>
+        <GroupChatMessageList roomId={roomId} />
+      </div>
+
+      {/* 메시지 입력창 */}
+      <GroupChatInput roomId={roomId} />
+    </div>
+  );
+}

--- a/fe/src/features/auth/types/roles.ts
+++ b/fe/src/features/auth/types/roles.ts
@@ -1,0 +1,9 @@
+export enum DepartmentRole {
+  MEMBER = 'MEMBER',
+  TEAM_LEAD = 'TEAM_LEAD',
+}
+
+export enum ProjectRole {
+  MEMBER = 'MEMBER',
+  PROJECT_LEADER = 'PROJECT_LEADER',
+}

--- a/fe/src/features/chat/group/components/GroupChatInput.tsx
+++ b/fe/src/features/chat/group/components/GroupChatInput.tsx
@@ -8,29 +8,80 @@ interface GroupChatInputProps {
 }
 
 export default function GroupChatInput({ roomId }: GroupChatInputProps) {
+  // [1] 입력 상태 정의
   const [content, setContent] = useState('');
+  // [2] 중복 전송 방지용 상태
+  const [isSending, setIsSending] = useState(false);
+
+  // [3] 그룹 채팅 메시지 전송 함수
   const { sendGroupMessage } = useGroupChat(roomId);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  // [4] 전송 처리 함수
+  const handleSubmit = async (e: React.FormEvent | React.KeyboardEvent) => {
     e.preventDefault();
-    if (!content.trim()) return;
-    sendGroupMessage(content);
-    setContent('');
+
+    // 입력값이 공백만 있을 경우 전송 방지
+    if (!content.trim() || isSending) return;
+
+    try {
+      setIsSending(true);
+      // 전송 시 서버로 메시지 전송, async 처리로 실패 대응 가능
+      await sendGroupMessage(content);
+      setContent('');
+    } catch (err) {
+      console.error('메시지 전송 실패:', err); // 에러 핸들링
+      alert('메시지 전송에 실패했습니다.');
+    } finally {
+      setIsSending(false);
+    }
   };
 
   return (
+    // [4] 채팅 입력 폼 렌더링
     <form
       onSubmit={handleSubmit}
-      style={{ display: 'flex', gap: '8px', padding: '12px' }}
+      style={{
+        display: 'flex',
+        gap: '8px',
+        padding: '12px',
+        borderTop: '1px solid #ddd', // 상단 구분선
+        backgroundColor: '#fff',
+      }}
     >
+      {/* [5] 입력창 */}
       <input
         type="text"
         placeholder="메시지를 입력하세요"
         value={content}
         onChange={(e) => setContent(e.target.value)}
-        style={{ flex: 1, padding: '8px' }}
+        onKeyDown={(e) => {
+          // Enter로 메시지 전송 (Shift+Enter 제외)
+          if (e.key === 'Enter' && !e.shiftKey) handleSubmit(e);
+        }}
+        disabled={isSending} // 전송 중 입력 비활성화
+        style={{
+          flex: 1,
+          padding: '10px',
+          border: '1px solid #ccc',
+          borderRadius: '6px',
+          fontSize: '14px',
+          backgroundColor: isSending ? '#f5f5f5' : 'white',
+        }}
       />
-      <button type="submit" style={{ padding: '8px 16px' }}>
+      <button
+        type="submit"
+        disabled={!content.trim() || isSending} // 전송 조건 및 중복 방지
+        style={{
+          padding: '10px 16px',
+          backgroundColor: '#0070f3',
+          color: '#fff',
+          border: 'none',
+          borderRadius: '6px',
+          cursor: 'pointer',
+          fontWeight: 'bold',
+          opacity: !content.trim() || isSending ? 0.6 : 1,
+        }}
+      >
         전송
       </button>
     </form>

--- a/fe/src/features/chat/group/components/GroupChatMessageList.tsx
+++ b/fe/src/features/chat/group/components/GroupChatMessageList.tsx
@@ -1,16 +1,51 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { useGroupChat } from '@/features/chat/group/services/useGroupChat';
 import { ChatMessagePayload } from '@/features/chat/common/types/ChatMessagePayload';
+import { fetchGroupChatMessages } from '@/features/chat/group/services/fetchGroupChatMessages';
 
 interface GroupChatMessageListProps {
   roomId: number;
 }
 
+// 시간 포맷팅 함수 분리
+const formatTimestamp = (timestamp: string | undefined): string => {
+  if (!timestamp) return '시간 없음';
+  return new Date(timestamp).toLocaleString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
 export default function GroupChatMessageList({
   roomId,
 }: GroupChatMessageListProps) {
-  const { messages } = useGroupChat(roomId);
+  const [initialMessages, setInitialMessages] = useState<ChatMessagePayload[]>(
+    []
+  );
+  const { messages: liveMessages } = useGroupChat(roomId);
+
+  // 최초 진입 시 메시지 불러오기
+  useEffect(() => {
+    if (!roomId || isNaN(roomId)) return;
+
+    const loadMessages = async () => {
+      try {
+        const data = await fetchGroupChatMessages(roomId);
+        setInitialMessages(data);
+      } catch (err) {
+        console.error('채팅 메시지 불러오기 실패:', err);
+      }
+    };
+    loadMessages();
+  }, [roomId]);
+
+  // 초기 메시지 + 실시간 메시지 합치기
+  const allMessages = [...initialMessages, ...liveMessages];
 
   return (
     <div
@@ -21,27 +56,21 @@ export default function GroupChatMessageList({
         gap: '8px',
       }}
     >
-      {messages.map((msg: ChatMessagePayload, idx: number) => (
+      {allMessages.map((msg: ChatMessagePayload, idx: number) => (
         <div
-          key={idx}
-          style={{ background: '#f0f0f0', padding: '8px', borderRadius: '6px' }}
+          key={`${msg.createdAt}-${msg.senderId}-${idx}`} // 고유 key 생성
+          style={{
+            background: '#f0f0f0',
+            padding: '8px',
+            borderRadius: '6px',
+          }}
         >
           <div style={{ fontSize: '14px', color: '#888' }}>
             From: {msg.senderId ?? '알 수 없음'}
           </div>
           <div>{msg.content}</div>
           <div style={{ fontSize: '12px', color: '#aaa' }}>
-            {msg.format}
-            {' · '}
-            {msg.createdAt
-              ? new Date(msg.createdAt).toLocaleString('ko-KR', {
-                  year: 'numeric',
-                  month: '2-digit',
-                  day: '2-digit',
-                  hour: '2-digit',
-                  minute: '2-digit',
-                })
-              : '시간 없음'}
+            {msg.format} · {formatTimestamp(msg.createdAt)}
           </div>
         </div>
       ))}

--- a/fe/src/features/chat/group/components/GroupChatRoomHeader.tsx
+++ b/fe/src/features/chat/group/components/GroupChatRoomHeader.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { fetchGroupChatRoomInfo } from '@/features/chat/group/services/fetchGroupChatRoomInfo';
+import { GroupChatRoom } from '@/features/chat/group/types/GroupChatRoom';
+
+// roomId 기반 fetch 구조
+export default function GroupChatRoomHeader() {
+  //  Next.js 동적 라우팅에서 roomId 추출
+  const { roomId } = useParams();
+  const parsedRoomId = Number(roomId);
+
+  // 상태 정의
+  const [room, setRoom] = useState<GroupChatRoom | null>(null);
+
+  // fetch 요청으로 방 정보 가져오기
+  useEffect(() => {
+    if (!parsedRoomId) return;
+    fetchGroupChatRoomInfo(parsedRoomId)
+      .then(setRoom)
+      .catch((err) => {
+        console.error('채팅방 정보 조회 실패:', err);
+      });
+  }, [parsedRoomId]);
+
+  // 로딩 처리
+  if (!room) return <div>채팅방 정보를 불러오는 중...</div>;
+
+  return (
+    <div style={{ padding: '12px', borderBottom: '1px solid #ddd' }}>
+      {/* room.name 표시 */}
+      <h2>{room.name}</h2>
+
+      {/* 유형 및 소속 텍스트 출력 */}
+      <div style={{ fontSize: '14px', color: '#666' }}>
+        유형: {room.roomType === 'ARCHIVE' ? '자료방' : '일반방'} / 소속:{' '}
+        {room.scope === 'PROJECT' ? '프로젝트' : '부서'}
+      </div>
+    </div>
+  );
+}

--- a/fe/src/features/chat/group/services/fetchGroupChatMessages.ts
+++ b/fe/src/features/chat/group/services/fetchGroupChatMessages.ts
@@ -1,0 +1,23 @@
+import { apiClient } from '@/lib/api/apiClient';
+import { ChatMessagePayload } from '@/features/chat/common/types/ChatMessagePayload';
+
+/**
+ * 특정 그룹 채팅방의 메시지 목록을 가져오는 함수
+ * @param roomId - 조회할 채팅방 ID
+ * @returns 메시지 목록 (최신순)
+ * - 기본적으로 최신 메시지 20개를 가져옵니다.
+ * - 이후 무한스크롤이 필요할 경우 cursor 파라미터 활용 가능
+ */
+export async function fetchGroupChatMessages(
+  roomId: number
+): Promise<ChatMessagePayload[]> {
+  try {
+    const res = await apiClient<ChatMessagePayload[]>(
+      `/api/v1/group-chats/${roomId}/messages`
+    );
+    return res;
+  } catch (error) {
+    console.error('그룹 채팅 메시지 불러오기 실패:', error);
+    return [];
+  }
+}

--- a/fe/src/features/chat/group/services/fetchGroupChatRoomInfo.ts
+++ b/fe/src/features/chat/group/services/fetchGroupChatRoomInfo.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { apiClient } from '@/lib/api/apiClient';
+import { GroupChatRoom } from '@/features/chat/group/types/GroupChatRoom';
+
+/**
+ * 그룹 채팅방 정보를 가져오는 함수
+ * - GET /api/v1/group-chats/{roomId}
+ * - 실패 시 콘솔 출력 + 예외 전파
+ */
+export async function fetchGroupChatRoomInfo(
+  roomId: number
+): Promise<GroupChatRoom> {
+  try {
+    // 백엔드로부터 채팅방 정보 요청
+    const res = await apiClient<GroupChatRoom>(`/api/v1/group-chats/${roomId}`);
+    console.log('채팅방 정보 불러오기 성공:', res);
+
+    // 정상 응답 반환
+    return res;
+  } catch (error) {
+    // 실패 시 콘솔 출력 및 에러 전파
+    console.error(`채팅방 정보 조회 실패(roomId: ${roomId})`, error);
+    throw error;
+  }
+}

--- a/fe/src/features/chat/group/services/fetchGroupChatRoomSummaries.ts
+++ b/fe/src/features/chat/group/services/fetchGroupChatRoomSummaries.ts
@@ -1,0 +1,14 @@
+// 그룹 채팅방 요약 목록을 받아오는 API 호출 함수
+import { apiClient } from '@/lib/api/apiClient';
+import { GroupChatRoomSummary } from '@/features/chat/group/types/GroupChatRoomSummary';
+import { ChatScope } from '@/features/chat/common/types/ChatScope';
+
+// scope에 따라 그룹 채팅방 목록 조회 API 요청
+export async function fetchGroupChatRoomSummaries(
+  scope: ChatScope
+): Promise<GroupChatRoomSummary[]> {
+  const res = await apiClient<GroupChatRoomSummary[]>(
+    `/api/v1/group-chats/rooms?scope=${scope}`
+  );
+  return res;
+}

--- a/fe/src/features/chat/group/services/useGroupChatMessages.ts
+++ b/fe/src/features/chat/group/services/useGroupChatMessages.ts
@@ -1,0 +1,48 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { ChatMessagePayload } from '@/features/chat/common/types/ChatMessagePayload';
+import { connectWebSocket, onMessage } from '@/lib/socket';
+import { ChatRoomType } from '@/features/chat/common/types/ChatRoomType';
+import { fetchGroupChatMessages } from './fetchGroupChatMessages';
+
+/**
+ * 그룹 채팅방 내 메시지를 받아오는 훅
+ * - 초기 메시지 목록은 API를 통해 가져옴
+ * - 이후 WebSocket을 통해 실시간 메시지를 수신
+ */
+export function useGroupChatMessages(roomId: number) {
+  const [messages, setMessages] = useState<ChatMessagePayload[]>([]);
+
+  // 1. 초기 메시지 목록 불러오기
+  useEffect(() => {
+    const loadMessages = async () => {
+      try {
+        const initialMessages = await fetchGroupChatMessages(roomId);
+        setMessages(initialMessages);
+      } catch (error) {
+        console.error('채팅 메시지 로딩 실패:', error);
+      }
+    };
+
+    loadMessages();
+  }, [roomId]);
+
+  // 2. WebSocket 수신 메시지 핸들링
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (token) {
+      connectWebSocket(token);
+    }
+
+    onMessage((msg: ChatMessagePayload) => {
+      if (msg.chatType === ChatRoomType.GROUP && msg.roomId === roomId) {
+        setMessages((prev) => [...prev, msg]);
+      }
+    });
+  }, [roomId]);
+
+  return {
+    messages,
+  };
+}

--- a/fe/src/features/chat/group/types/GroupChatRoom.ts
+++ b/fe/src/features/chat/group/types/GroupChatRoom.ts
@@ -1,0 +1,9 @@
+export interface GroupChatRoom {
+  roomId: number;
+  name: string;
+  roomType: 'NORMAL' | 'ARCHIVE'; // 또는 enum RoomType
+  teamId: number;
+  scope: 'DEPARTMENT' | 'PROJECT'; // 또는 enum ChatScope
+  createdBy: number;
+  projectEndDate?: string; // null 가능
+}


### PR DESCRIPTION
### 그룹 채팅방 상세 진입 시 채팅방 정보와 메시지 목록을 출력하는 UI 구현
- 채팅방 메타 정보(제목, 유형, 소속)를 헤더에 출력
- 초기 메시지 목록 fetch 후 WebSocket 기반 실시간 메시지 append
- 메시지 입력창에서 Enter 키로 전송 + 전송 실패 시 에러 메시지 처리
- 타입 정리 및 서비스 함수(`fetchGroupChatRoomInfo` 등) 추가

### 구현 파일
- `/group/[roomId]/page.tsx`에서:
   - 채팅방 진입 시 `roomId` 기반 채팅방 정보 fetch
   - 채팅방 메타 정보 (제목, 유형, 소속 등) 출력
   - 채팅 메시지 목록 fetch 및 실시간 메시지 append
   - 메시지 입력 후 Enter 전송 처리

- 컴포넌트 분리:
   - `GroupChatRoomHeader.tsx` — 채팅방 정보 헤더
   - `GroupChatMessageList.tsx` — 초기 메시지 + 실시간 메시지 출력
   - `GroupChatInput.tsx` — 메시지 입력창 (Enter 전송 + 에러 핸들링)

- 타입 정의 및 서비스 함수 구현:
   - `GroupChatRoom.ts`, `GroupChatRoomSummary.ts`, `ChatMessagePayload.ts`
   - `fetchGroupChatRoomInfo`, `fetchGroupChatMessages`, `useGroupChat`