### PR TITLE
[FE/FEAT] - 그룹 채팅방 생성 - 권한 진입 처리 및 폼 UI + API 연동

### DIFF
--- a/fe/src/app/(chat-detail)/group/create/page.tsx
+++ b/fe/src/app/(chat-detail)/group/create/page.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/features/auth/AuthProvider';
+import { Role, DepartmentRole, ProjectRole } from '@/features/auth/types/roles';
+import { ChatScope } from '@/features/chat/common/types/ChatScope';
+import { RoomType } from '@/features/chat/common/types/RoomType';
+import { createGroupChatRoom } from '@/features/chat/group/services/createGroupChatRoom';
+
+export default function GroupChatRoomCreatePage() {
+  const router = useRouter();
+  const { user, loading } = useAuth();
+
+  // 폼 상태 정의
+  const [name, setName] = useState('');
+  const [roomType, setRoomType] = useState<RoomType>(RoomType.NORMAL);
+  const [scope, setScope] = useState<ChatScope>(ChatScope.DEPARTMENT);
+  const [teamId, setTeamId] = useState('');
+  const [projectEndDate, setProjectEndDate] = useState('');
+
+  // 폼 제출 핸들러
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name || !teamId) {
+      alert('채팅방 이름과 팀 ID는 필수입니다.');
+      return;
+    }
+
+    const formData = {
+      name,
+      roomType,
+      scope,
+      teamId: Number(teamId),
+      projectEndDate: projectEndDate || null,
+    };
+
+    try {
+      await createGroupChatRoom(formData);
+      alert('채팅방이 생성되었습니다!');
+      router.push('/group'); // 생성 후 목록으로 이동
+    } catch (err) {
+      console.error('채팅방 생성 실패:', err);
+      alert('채팅방 생성에 실패했습니다.');
+    }
+  };
+
+  // 권한 여부 확인
+  const isAuthorized =
+    user?.role === Role.ADMIN ||
+    user?.departmentRole === DepartmentRole.TEAM_LEAD ||
+    user?.projectRole === ProjectRole.PROJECT_LEADER;
+
+  useEffect(() => {
+    if (!loading && !isAuthorized) {
+      alert('접근 권한이 없습니다.');
+      router.replace('/group'); // 권한 없을 시 목록 페이지로 이동
+    }
+  }, [loading, isAuthorized, router]);
+
+  // [1] 로딩 중일 때는 로딩 표시
+  if (loading) return <div>로딩 중...</div>;
+  // [2] 권한이 없으면 리다이렉트 or 안내 메시지
+  if (!isAuthorized) return null;
+
+  // [3] 정상 접근 시 채팅방 생성 폼 출력
+  return (
+    <div style={{ padding: '24px' }}>
+      <h2>그룹 채팅방 생성</h2>
+      <form
+        onSubmit={handleSubmit}
+        style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}
+      >
+        <label>
+          채팅방 이름
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </label>
+
+        <label>
+          방 타입
+          <select
+            value={roomType}
+            onChange={(e) => setRoomType(e.target.value as RoomType)}
+          >
+            <option value={RoomType.NORMAL}>일반방</option>
+            <option value={RoomType.ARCHIVE}>자료방</option>
+          </select>
+        </label>
+
+        <label>
+          소속
+          <select
+            value={scope}
+            onChange={(e) => setScope(e.target.value as ChatScope)}
+          >
+            <option value={ChatScope.DEPARTMENT}>부서</option>
+            <option value={ChatScope.PROJECT}>프로젝트</option>
+          </select>
+        </label>
+
+        <label>
+          팀 ID
+          <input
+            type="number"
+            value={teamId}
+            onChange={(e) => setTeamId(e.target.value)}
+          />
+        </label>
+
+        {scope === 'PROJECT' && (
+          <label>
+            프로젝트 종료일 (선택)
+            <input
+              type="date"
+              value={projectEndDate}
+              onChange={(e) => setProjectEndDate(e.target.value)}
+            />
+          </label>
+        )}
+
+        <button type="submit" style={{ marginTop: '16px' }}>
+          채팅방 생성
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/fe/src/app/(chat-detail)/group/page.tsx
+++ b/fe/src/app/(chat-detail)/group/page.tsx
@@ -1,5 +1,131 @@
-import GroupChatRoomList from '@/features/chat/group/components/GroupChatRoomList';
+'use client';
 
-export default function GroupChatRoomListPage() {
-  return <GroupChatRoomList />;
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/features/auth/AuthProvider';
+import { Role, DepartmentRole, ProjectRole } from '@/features/auth/types/roles';
+import { ChatScope } from '@/features/chat/common/types/ChatScope';
+import { RoomType } from '@/features/chat/common/types/RoomType';
+import { createGroupChatRoom } from '@/features/chat/group/services/createGroupChatRoom';
+
+export default function GroupChatRoomCreatePage() {
+  const router = useRouter();
+  const { user, loading } = useAuth();
+
+  // 폼 상태 정의
+  const [name, setName] = useState('');
+  const [roomType, setRoomType] = useState<RoomType>(RoomType.NORMAL);
+  const [scope, setScope] = useState<ChatScope>(ChatScope.DEPARTMENT);
+  const [teamId, setTeamId] = useState('');
+  const [projectEndDate, setProjectEndDate] = useState('');
+
+  // 폼 제출 핸들러
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name || !teamId) {
+      alert('채팅방 이름과 팀 ID는 필수입니다.');
+      return;
+    }
+
+    const formData = {
+      name,
+      roomType,
+      scope,
+      teamId: Number(teamId),
+      projectEndDate: projectEndDate || null,
+    };
+
+    try {
+      await createGroupChatRoom(formData);
+      alert('채팅방이 생성되었습니다!');
+      router.push('/group'); // 생성 후 목록으로 이동
+    } catch (err) {
+      console.error('채팅방 생성 실패:', err);
+      alert('채팅방 생성에 실패했습니다.');
+    }
+  };
+
+  // 권한 여부 확인
+  const isAuthorized =
+    user?.role === Role.ADMIN ||
+    user?.departmentRole === DepartmentRole.TEAM_LEAD ||
+    user?.projectRole === ProjectRole.PROJECT_LEADER;
+
+  useEffect(() => {
+    if (!loading && !isAuthorized) {
+      alert('접근 권한이 없습니다.');
+      router.replace('/group'); // 권한 없을 시 목록 페이지로 이동
+    }
+  }, [loading, isAuthorized, router]);
+
+  // [1] 로딩 중일 때는 로딩 표시
+  if (loading) return <div>로딩 중...</div>;
+  // [2] 권한이 없으면 리다이렉트 or 안내 메시지
+  if (!isAuthorized) return null;
+
+  // [3] 정상 접근 시 채팅방 생성 폼 출력
+  return (
+    <div style={{ padding: '24px' }}>
+      <h2>그룹 채팅방 생성</h2>
+      <form
+        onSubmit={handleSubmit}
+        style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}
+      >
+        <label>
+          채팅방 이름
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </label>
+
+        <label>
+          방 타입
+          <select
+            value={roomType}
+            onChange={(e) => setRoomType(e.target.value as RoomType)}
+          >
+            <option value={RoomType.NORMAL}>일반방</option>
+            <option value={RoomType.ARCHIVE}>자료방</option>
+          </select>
+        </label>
+
+        <label>
+          소속
+          <select
+            value={scope}
+            onChange={(e) => setScope(e.target.value as ChatScope)}
+          >
+            <option value={ChatScope.DEPARTMENT}>부서</option>
+            <option value={ChatScope.PROJECT}>프로젝트</option>
+          </select>
+        </label>
+
+        <label>
+          팀 ID
+          <input
+            type="number"
+            value={teamId}
+            onChange={(e) => setTeamId(e.target.value)}
+          />
+        </label>
+
+        {scope === 'PROJECT' && (
+          <label>
+            프로젝트 종료일 (선택)
+            <input
+              type="date"
+              value={projectEndDate}
+              onChange={(e) => setProjectEndDate(e.target.value)}
+            />
+          </label>
+        )}
+
+        <button type="submit" style={{ marginTop: '16px' }}>
+          채팅방 생성
+        </button>
+      </form>
+    </div>
+  );
 }

--- a/fe/src/features/auth/types/roles.ts
+++ b/fe/src/features/auth/types/roles.ts
@@ -1,3 +1,8 @@
+export enum Role {
+  ADMIN = 'ADMIN',
+  USER = 'USER',
+}
+
 export enum DepartmentRole {
   MEMBER = 'MEMBER',
   TEAM_LEAD = 'TEAM_LEAD',

--- a/fe/src/features/auth/types/user.ts
+++ b/fe/src/features/auth/types/user.ts
@@ -1,5 +1,5 @@
 // 사용자 타입 정의
-
+import { Role, DepartmentRole, ProjectRole } from './roles';
 export interface Department {
   departmentName: string;
 }
@@ -9,6 +9,8 @@ export interface CurrentUser {
   name: string;
   nickname: string;
   departmentName: string;
-  role: string;
+  departmentRole: DepartmentRole;
+  projectRole: ProjectRole;
+  role: Role;
   email: string;
 }

--- a/fe/src/features/chat/group/services/createGroupChatRoom.ts
+++ b/fe/src/features/chat/group/services/createGroupChatRoom.ts
@@ -1,0 +1,11 @@
+import { apiClient } from '@/lib/api/apiClient';
+import { GroupChatRoomCreateRequest } from '../types/GroupChatRoomCreateRequest';
+
+export async function createGroupChatRoom(
+  payload: GroupChatRoomCreateRequest
+): Promise<void> {
+  await apiClient('/api/v1/group-chats', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}

--- a/fe/src/features/chat/group/types/GroupChatRoomCreateRequest.ts
+++ b/fe/src/features/chat/group/types/GroupChatRoomCreateRequest.ts
@@ -1,0 +1,10 @@
+import { RoomType } from '@/features/chat/common/types/RoomType';
+import { ChatScope } from '@/features/chat/common/types/ChatScope';
+
+export interface GroupChatRoomCreateRequest {
+  name: string;
+  roomType: RoomType;
+  scope: ChatScope;
+  teamId: number;
+  projectEndDate: string | null;
+}


### PR DESCRIPTION
## 💡 어떤 기능인가요?
- 그룹 채팅방 생성 폼
- 관리자, 부서장, 프로젝트 리더만 진입 가능하도록 권한 조건부 렌더링 적용
- 채팅방 이름, 타입, 소속, 팀 ID, 프로젝트 종료일을 입력할 수 있으며, 생성 API와 연동되어 있음

## 🤔 왜 필요한가요?
- 실사용자가 직접 채팅방을 생성할 수 있도록 기능을 제공하고,
- 역할 기반으로 생성 권한을 제한해 보안성과 실무 흐름을 반영.

## ✅ 구현 내용 요약
- `/chat-detail/group/create` 경로에 진입 시 조건부 접근 제한 처리
- 폼 구성 및 입력값 유효성 검사
- `POST /api/v1/group-chats` 연동
- 생성 성공 시 목록으로 리다이렉트
- 타입 정의 및 enum 처리

## 📌 TODO (후속 예정)
- 생성 후 자동 진입 처리
- 자료방 자동 생성 여부 연동
- 팀 ID/프로젝트 목록 선택 UI (현재는 수동 입력)
