### PR TITLE
[BE,FE/FEAT] DM 채팅방 생성 및 중복 방지 로직 구현, DM 상대 선택 UI 및 채팅방 생성 요청 기능 구현, …

### DIFF
--- a/be/src/main/java/com/example/mingle/domain/user/user/controller/ApiV1UserController.java
+++ b/be/src/main/java/com/example/mingle/domain/user/user/controller/ApiV1UserController.java
@@ -1,0 +1,21 @@
+package com.example.mingle.domain.user.user.controller;
+
+import com.example.mingle.domain.user.user.dto.UserSimpleDto;
+import com.example.mingle.domain.user.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class ApiV1UserController {
+
+    private final UserService userService;
+
+    // [1] 닉네임 키워드로 유저 검색
+    @GetMapping
+    public List<UserSimpleDto> searchUsers(@RequestParam String keyword) {
+        return userService.searchByNickname(keyword);
+    }
+}

--- a/be/src/main/java/com/example/mingle/domain/user/user/dto/UserResponseDto.java
+++ b/be/src/main/java/com/example/mingle/domain/user/user/dto/UserResponseDto.java
@@ -1,3 +1,4 @@
+// 전체 정보 반환
 package com.example.mingle.domain.user.user.dto;
 
 import com.example.mingle.domain.user.user.entity.User;

--- a/be/src/main/java/com/example/mingle/domain/user/user/dto/UserSimpleDto.java
+++ b/be/src/main/java/com/example/mingle/domain/user/user/dto/UserSimpleDto.java
@@ -1,5 +1,7 @@
+// 선택이나 리스트, 검색 등 간단한 표시용
 package com.example.mingle.domain.user.user.dto;
 
+import com.example.mingle.domain.user.user.entity.User;
 import lombok.*;
 
 @Getter
@@ -11,4 +13,12 @@ public class UserSimpleDto {
     private Long id;
     private String nickname;
     private String email;
+
+    public static UserSimpleDto from(User user) {
+        return UserSimpleDto.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .build();
+    }
 }

--- a/be/src/main/java/com/example/mingle/domain/user/user/repository/UserRepository.java
+++ b/be/src/main/java/com/example/mingle/domain/user/user/repository/UserRepository.java
@@ -30,6 +30,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     //부서명으로 사용자 목록 찾기
     List<User> findByDepartment_DepartmentName(String departmentName);
 
+    List<User> findByNicknameContaining(String keyword);
+
     //사용자를 이름으로 찾기
     Optional<User> findByName(String name);
 

--- a/be/src/main/java/com/example/mingle/domain/user/user/service/UserService.java
+++ b/be/src/main/java/com/example/mingle/domain/user/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.example.mingle.domain.user.team.entity.Department;
 import com.example.mingle.domain.user.team.repository.DepartmentRepository;
 import com.example.mingle.domain.user.user.dto.ProfileUpdateRequestDto;
 import com.example.mingle.domain.user.user.dto.SignupRequestDto;
+import com.example.mingle.domain.user.user.dto.UserSimpleDto;
 import com.example.mingle.domain.user.user.entity.*;
 import com.example.mingle.domain.user.user.repository.UserPositionRepository;
 import com.example.mingle.domain.user.user.repository.UserRepository;
@@ -120,5 +121,14 @@ public class UserService {
         return userRepository.findByIdWithRelations(id)
                 .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
     }
+
+
+
+    public List<UserSimpleDto> searchByNickname(String keyword) {
+        return userRepository.findByNicknameContaining(keyword).stream()
+                .map(UserSimpleDto::from)
+                .toList();
+    }
+
 
 }

--- a/fe/src/features/chat/dm/components/DmChatMessageList.tsx
+++ b/fe/src/features/chat/dm/components/DmChatMessageList.tsx
@@ -14,6 +14,9 @@ export default function DmChatMessageList({
 }: DmChatMessageListProps) {
   const { messages } = useDmChat(roomId, receiverId);
 
+  // 현재 로그인한 사용자 ID (임시: 로컬에서 가져옴)
+  const currentUserId = Number(localStorage.getItem('userId'));
+
   return (
     <div
       style={{
@@ -23,23 +26,33 @@ export default function DmChatMessageList({
         gap: '8px',
       }}
     >
-      {messages.map((msg: ChatMessagePayload, idx: number) => (
-        <div
-          key={idx}
-          style={{
-            background: '#fff1f0',
-            padding: '8px',
-            borderRadius: '6px',
-            border: '1px solid #ffccc7',
-          }}
-        >
-          <div style={{ fontSize: '14px', color: '#888' }}>
-            From: {msg.senderId ?? '알 수 없음'}
+      {messages.map((msg: ChatMessagePayload, idx: number) => {
+        // 보낸 사람이 나인지 확인
+        const isMe = msg.senderId === currentUserId;
+
+        return (
+          <div
+            key={idx}
+            style={{
+              // 보낸 사람에 따라 메시지 위치와 스타일 다르게 적용
+              alignSelf: isMe ? 'flex-end' : 'flex-start', // 좌우 정렬
+              background: isMe ? '#d9f7be' : '#fff1f0', // 배경 색상 구분
+              padding: '8px',
+              borderRadius: '6px',
+              border: '1px solid #ccc',
+              maxWidth: '70%',
+              textAlign: isMe ? 'right' : 'left', // 텍스트 정렬
+            }}
+          >
+            <div style={{ fontSize: '14px', color: '#888' }}>
+              {/* 발신자 라벨링 */}
+              {isMe ? '나' : `상대(${msg.senderId})`}
+            </div>
+            <div>{msg.content}</div>
+            <div style={{ fontSize: '12px', color: '#aaa' }}>{msg.format}</div>
           </div>
-          <div>{msg.content}</div>
-          <div style={{ fontSize: '12px', color: '#aaa' }}>{msg.format}</div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/fe/src/features/chat/dm/components/DmUserSearch.tsx
+++ b/fe/src/features/chat/dm/components/DmUserSearch.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useUserSearch } from '@/features/user/search/services/useUserSearch';
+import { apiClient } from '@/lib/api/apiClient';
+
+export default function DmUserSearch() {
+  const [keyword, setKeyword] = useState('');
+  const router = useRouter();
+
+  const { results, loading, error } = useUserSearch(keyword);
+
+  const handleStartDm = async (opponentId: number) => {
+    const { roomId } = await apiClient<{ roomId: number }>('/api/v1/dm-chat', {
+      method: 'POST',
+      body: JSON.stringify({ opponentId }),
+    });
+    router.push(`/dm/${roomId}`);
+  };
+
+  return (
+    <div style={{ padding: '24px' }}>
+      <input
+        value={keyword}
+        onChange={(e) => setKeyword(e.target.value)} // 입력만으로 자동 검색
+        placeholder="닉네임 검색"
+      />
+      {loading && <p>검색 중...</p>}
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+
+      {results.map((user) => (
+        <div key={user.id}>
+          <span>
+            {user.nickname} ({user.email})
+          </span>
+          <button onClick={() => handleStartDm(user.id)}>DM 보내기</button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/fe/src/features/user/search/services/useUserSearch.ts
+++ b/fe/src/features/user/search/services/useUserSearch.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { apiClient } from '@/lib/api/apiClient';
+import { UserSimpleDto } from '@/features/user/search/types/UserSimpleDto';
+
+export function useUserSearch(keyword: string) {
+  const [results, setResults] = useState<UserSimpleDto[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!keyword || keyword.trim() === '') {
+      setResults([]);
+      return;
+    }
+
+    const fetchUsers = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await apiClient<UserSimpleDto[]>(
+          `/api/v1/users/search?keyword=${encodeURIComponent(keyword)}`
+        );
+        setResults(data);
+      } catch (err) {
+        console.error(err);
+        setError('유저 검색에 실패했습니다.');
+        setResults([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchUsers();
+  }, [keyword]);
+
+  return { results, loading, error };
+}

--- a/fe/src/features/user/search/types/UserSimpleDto.ts
+++ b/fe/src/features/user/search/types/UserSimpleDto.ts
@@ -1,0 +1,5 @@
+export interface UserSimpleDto {
+  id: number;
+  nickname: string;
+  email: string;
+}

--- a/fe/src/lib/socket.ts
+++ b/fe/src/lib/socket.ts
@@ -35,6 +35,16 @@ export function sendMessage(payload: ChatMessagePayload) {
   }
 }
 
-export function onMessage(handler: (msg: ChatMessagePayload) => void) {
+export function onMessage(
+  handler: (msg: ChatMessagePayload) => void
+): () => void {
   messageHandlers.push(handler);
+
+  // 🔧 반환: 제거 함수
+  return () => {
+    const index = messageHandlers.indexOf(handler);
+    if (index !== -1) {
+      messageHandlers.splice(index, 1);
+    }
+  };
 }


### PR DESCRIPTION
## 💜 어떤 기능인가요?
- DM 채팅방을 생성할 수 있는 전체 흐름 구현
- 동일 상대와의 채팅방이 이미 존재할 경우 새로 생성하지 않고 기존 방 ID로 응답
- 프론트에서는 유저 검색 → 상대 선택 → POST 요청 → 채팅방 입장 흐름을 제공
- 채팅 UI에서 내가 보낸 메시지와 상대 메시지를 시각적으로 구분

## 🔧 상세 변경 사항
### 백엔드
- `DmChatRoomService`
   - `createDmRoom()` 메서드 구현
   - 동일 유저와의 채팅방 존재 여부 확인 후 분기 처리
- `DmChatRoomController`
   - `@PostMapping` API 추가: `/api/v1/dm-chat`
   - 요청 시 기존 채팅방 존재 여부 확인 후 ID 반환
- `UserService`
   - `searchByNickname(String)` 메서드 추가: 닉네임 기준 유저 검색
- `UserSimpleDto`
   - 백엔드 → 프론트로 전달되는 간단 유저 정보 응답용 DTO 생성

### 프론트엔드
- `DmUserSearch.tsx`
   - 유저 검색 및 "DM 보내기" 버튼 구현
   - POST `/api/v1/dm-chat` 호출 → `roomId` 받아 채팅방으로 이동
- `useUserSearch.ts`
   - 키워드로 유저 검색하는 커스텀 훅 추가 (API 연동 포함)
- `DmChatRoomList.tsx`, `DmChatMessageList.tsx`
   - 메시지 UI 개선: 송신자/수신자에 따라 좌/우 정렬, 색상 분리
- `socket.ts`, `useDmChat.ts`
   - 수신 메시지 핸들러 메모리 누수 방지 (정리 함수 반환 패턴 적용)

## 🙆‍♀️ 앞으로 할 일
- DM 채팅 상세 UI 개선 (스크롤/날짜/첨부파일 등)
- 실시간 읽음 처리, 상대 정보(이름/이미지) 표시 기능 추가 논의 가능

