### PR TITLE
[FE/ENHANCE] DM 채팅 UI 개선 - 날짜 구분선, 전송 시간, 자동 스크롤 추가

### DIFF
--- a/fe/src/features/chat/dm/components/DmChatMessageList.module.css
+++ b/fe/src/features/chat/dm/components/DmChatMessageList.module.css
@@ -1,0 +1,59 @@
+.chatList {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 60vh;
+  overflow-y: auto;
+  background-color: #fff;
+}
+
+.dateSeparator {
+  text-align: center;
+  margin: 16px 0;
+  font-weight: bold;
+  color: #999;
+  font-size: 14px;
+}
+
+.chatBubble {
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+  max-width: 70%;
+}
+
+.mine {
+  align-self: flex-end;
+  background: #d9f7be;
+}
+
+.opponent {
+  align-self: flex-start;
+  background: #fff1f0;
+}
+
+.senderLabel {
+  font-size: 13px;
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+
+.mine .senderLabel {
+  color: #389e0d;
+}
+
+.opponent .senderLabel {
+  color: #cf1322;
+}
+
+.messageText {
+  font-size: 14px;
+}
+
+.timeStamp {
+  font-size: 12px;
+  color: #aaa;
+  margin-top: 6px;
+  text-align: right;
+}

--- a/fe/src/features/chat/dm/components/DmChatMessageList.tsx
+++ b/fe/src/features/chat/dm/components/DmChatMessageList.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import styles from './DmChatMessageList.module.css';
+import { useEffect, useRef } from 'react';
 import { useDmChat } from '@/features/chat/dm/services/useDmChat';
 import { ChatMessagePayload } from '@/features/chat/common/types/ChatMessagePayload';
 
@@ -7,6 +9,16 @@ interface DmChatMessageListProps {
   roomId: number;
   receiverId: number;
 }
+
+// 날짜 추출 유틸
+const getDateString = (dateStr: string) => dateStr.split('T')[0];
+
+// 시간 포맷 유틸
+const getTimeString = (dateStr: string) =>
+  new Date(dateStr).toLocaleTimeString('ko-KR', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
 
 export default function DmChatMessageList({
   roomId,
@@ -17,42 +29,67 @@ export default function DmChatMessageList({
   // 현재 로그인한 사용자 ID (임시: 로컬에서 가져옴)
   const currentUserId = Number(localStorage.getItem('userId'));
 
+  const bottomRef = useRef<HTMLDivElement | null>(null); // 스크롤 타겟 ref
+
+  // 메시지 변화 시 스크롤 하단 고정
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
   return (
-    <div
-      style={{
-        padding: '12px',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '8px',
-      }}
-    >
+    <div className={styles.chatList}>
       {messages.map((msg: ChatMessagePayload, idx: number) => {
         // 보낸 사람이 나인지 확인
         const isMe = msg.senderId === currentUserId;
 
+        const messageDate = getDateString(msg.createdAt);
+
+        const shouldShowDate =
+          idx === 0 ||
+          messageDate !== getDateString(messages[idx - 1].createdAt);
+
         return (
-          <div
-            key={idx}
-            style={{
-              // 보낸 사람에 따라 메시지 위치와 스타일 다르게 적용
-              alignSelf: isMe ? 'flex-end' : 'flex-start', // 좌우 정렬
-              background: isMe ? '#d9f7be' : '#fff1f0', // 배경 색상 구분
-              padding: '8px',
-              borderRadius: '6px',
-              border: '1px solid #ccc',
-              maxWidth: '70%',
-              textAlign: isMe ? 'right' : 'left', // 텍스트 정렬
-            }}
-          >
-            <div style={{ fontSize: '14px', color: '#888' }}>
-              {/* 발신자 라벨링 */}
-              {isMe ? '나' : `상대(${msg.senderId})`}
+          <div key={idx}>
+            {/* 날짜 구분선 */}
+            {shouldShowDate && (
+              <div
+                className="date-separator"
+                style={{
+                  textAlign: 'center',
+                  margin: '16px 0',
+                  fontWeight: 'bold',
+                  color: '#999',
+                  fontSize: '14px',
+                }}
+              >
+                {new Date(msg.createdAt).toLocaleDateString('ko-KR', {
+                  year: 'numeric',
+                  month: '2-digit',
+                  day: '2-digit',
+                  weekday: 'short',
+                })}
+              </div>
+            )}
+
+            {/* 메시지 박스 */}
+            <div
+              className={`${styles.chatBubble} ${
+                isMe ? styles.mine : styles.opponent
+              }`}
+            >
+              <div className={styles.senderLabel}>
+                {isMe ? '나' : `상대(${msg.senderId})`}
+              </div>
+
+              <div className={styles.messageText}>{msg.content}</div>
+              <div className={styles.timeStamp}>
+                {getTimeString(msg.createdAt)}
+              </div>
             </div>
-            <div>{msg.content}</div>
-            <div style={{ fontSize: '12px', color: '#aaa' }}>{msg.format}</div>
           </div>
         );
       })}
+      <div ref={bottomRef} />
     </div>
   );
 }


### PR DESCRIPTION
## 💡 변경 내용
- DM 채팅 메시지 리스트에 다음 요소들을 추가 적용함
  - 날짜 구분선 표시 (날짜별 메시지 묶음)
  - 메시지 전송 시간 출력 (오른쪽 하단)
  - 최신 메시지 도착 시 자동 스크롤 (`scrollIntoView`)

## 🎨 스타일 처리
- CSS 모듈(`DmChatMessageList.module.css`)로 스타일 분리 및 정리
- "나 / 상대" 메시지 구분 색상 및 정렬 처리

## 🧪 테스트 방법
- DM 채팅방 진입 후 메시지 입력 시, 
  - 날짜별 구분선이 나타나는지
  - 메시지 시간 출력되는지
  - 메시지 수신 시 자동으로 아래로 스크롤되는지 확인

## 📁 관련 파일
- `features/chat/dm/components/DmChatMessageList.tsx`
- `features/chat/dm/components/DmChatMessageList.module.css`
