### PR TITLE
[FE/FEAT] group chat - 그룹 채팅 메시지 리스트 구현 및 초기 메시지 조회 통합

### DIFF
--- a/fe/src/features/chat/group/components/GroupChatMessageList.module.css
+++ b/fe/src/features/chat/group/components/GroupChatMessageList.module.css
@@ -1,0 +1,60 @@
+.chatList {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 60vh;
+  overflow-y: auto;
+  background-color: #fff;
+}
+
+.dateSeparator {
+  text-align: center;
+  margin: 16px 0;
+  font-weight: bold;
+  color: #999;
+  font-size: 14px;
+}
+
+.chatBubble {
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+  max-width: 70%;
+  word-break: break-word;
+}
+
+.mine {
+  align-self: flex-end;
+  background-color: #e6f4ff;
+}
+
+.opponent {
+  align-self: flex-start;
+  background-color: #fffbe6;
+}
+
+.senderLabel {
+  font-size: 13px;
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+
+.mine .senderLabel {
+  color: #096dd9;
+}
+
+.opponent .senderLabel {
+  color: #d48806;
+}
+
+.messageText {
+  font-size: 14px;
+}
+
+.timeStamp {
+  font-size: 12px;
+  color: #aaa;
+  margin-top: 6px;
+  text-align: right;
+}

--- a/fe/src/features/chat/group/components/GroupChatMessageList.tsx
+++ b/fe/src/features/chat/group/components/GroupChatMessageList.tsx
@@ -1,79 +1,77 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { useGroupChat } from '@/features/chat/group/services/useGroupChat';
 import { ChatMessagePayload } from '@/features/chat/common/types/ChatMessagePayload';
-import { fetchGroupChatMessages } from '@/features/chat/group/services/fetchGroupChatMessages';
-
+import styles from './GroupChatMessageList.module.css';
 interface GroupChatMessageListProps {
   roomId: number;
 }
 
-// 시간 포맷팅 함수 분리
-const formatTimestamp = (timestamp: string | undefined): string => {
-  if (!timestamp) return '시간 없음';
-  return new Date(timestamp).toLocaleString('ko-KR', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
+// 날짜 문자열 추출 유틸
+const getDateString = (dateStr: string) => dateStr.split('T')[0];
+
+// 시각 포맷 유틸
+const getTimeString = (dateStr: string) =>
+  new Date(dateStr).toLocaleTimeString('ko-KR', {
     hour: '2-digit',
     minute: '2-digit',
   });
-};
 
 export default function GroupChatMessageList({
   roomId,
 }: GroupChatMessageListProps) {
-  const [initialMessages, setInitialMessages] = useState<ChatMessagePayload[]>(
-    []
-  );
-  const { messages: liveMessages } = useGroupChat(roomId);
+  const { messages } = useGroupChat(roomId); // 초기 + 실시간 메시지 통합
+  const currentUserId = Number(localStorage.getItem('userId')); // 나와 상대방 구분
+  const bottomRef = useRef<HTMLDivElement | null>(null); // 자동 스크롤
 
-  // 최초 진입 시 메시지 불러오기
+  // 메시지 새로 추가될 때마다 자동 스크롤
   useEffect(() => {
-    if (!roomId || isNaN(roomId)) return;
-
-    const loadMessages = async () => {
-      try {
-        const data = await fetchGroupChatMessages(roomId);
-        setInitialMessages(data);
-      } catch (err) {
-        console.error('채팅 메시지 불러오기 실패:', err);
-      }
-    };
-    loadMessages();
-  }, [roomId]);
-
-  // 초기 메시지 + 실시간 메시지 합치기
-  const allMessages = [...initialMessages, ...liveMessages];
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
 
   return (
-    <div
-      style={{
-        padding: '12px',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '8px',
-      }}
-    >
-      {allMessages.map((msg: ChatMessagePayload, idx: number) => (
-        <div
-          key={`${msg.createdAt}-${msg.senderId}-${idx}`} // 고유 key 생성
-          style={{
-            background: '#f0f0f0',
-            padding: '8px',
-            borderRadius: '6px',
-          }}
-        >
-          <div style={{ fontSize: '14px', color: '#888' }}>
-            From: {msg.senderId ?? '알 수 없음'}
+    <div className={styles.chatList}>
+      {messages.map((msg: ChatMessagePayload, idx: number) => {
+        const isMe = msg.senderId === currentUserId;
+        const dateStr = getDateString(msg.createdAt);
+        const showDateDivider =
+          idx === 0 || dateStr !== getDateString(messages[idx - 1].createdAt); // 🔧 [수정] allMessages → messages
+
+        return (
+          <div key={`${msg.createdAt}-${msg.senderId}-${idx}`}>
+            {/* 날짜 구분선 */}
+            {showDateDivider && (
+              <div className={styles.dateSeparator}>
+                {new Date(msg.createdAt).toLocaleDateString('ko-KR', {
+                  year: 'numeric',
+                  month: '2-digit',
+                  day: '2-digit',
+                  weekday: 'short',
+                })}
+              </div>
+            )}
+
+            {/* 메시지 박스 */}
+            <div
+              className={`${styles.chatBubble} ${
+                isMe ? styles.mine : styles.opponent
+              }`}
+            >
+              <div className={styles.senderLabel}>
+                {isMe ? '나' : `사용자 ${msg.senderId}`}
+              </div>
+              <div className={styles.messageText}>{msg.content}</div>
+              <div className={styles.timeStamp}>
+                {getTimeString(msg.createdAt)}
+              </div>
+            </div>
           </div>
-          <div>{msg.content}</div>
-          <div style={{ fontSize: '12px', color: '#aaa' }}>
-            {msg.format} · {formatTimestamp(msg.createdAt)}
-          </div>
-        </div>
-      ))}
+        );
+      })}
+
+      {/* 자동 스크롤 타겟 */}
+      <div ref={bottomRef} />
     </div>
   );
 }

--- a/fe/src/features/chat/group/services/useGroupChat.ts
+++ b/fe/src/features/chat/group/services/useGroupChat.ts
@@ -5,23 +5,50 @@ import { ChatMessagePayload } from '@/features/chat/common/types/ChatMessagePayl
 import { ChatRoomType } from '@/features/chat/common/types/ChatRoomType';
 import { connectWebSocket, sendMessage, onMessage } from '@/lib/socket';
 import { MessageFormat } from '@/features/chat/common/types/MessageFormat';
+import { fetchGroupChatMessages } from './fetchGroupChatMessages'; // 초기 메시지 불러오기 위한 API
 
 export function useGroupChat(roomId: number) {
   const [messages, setMessages] = useState<ChatMessagePayload[]>([]);
 
+  // 초기 메시지 로딩
+  useEffect(() => {
+    if (!roomId || isNaN(roomId)) return;
+
+    const loadInitialMessages = async () => {
+      try {
+        const data = await fetchGroupChatMessages(roomId); // 🔧 [추가]
+        setMessages(data); // 🔧 [추가] 초기 메시지 저장
+      } catch (error) {
+        console.error('초기 그룹 채팅 메시지 로딩 실패:', error);
+      }
+    };
+
+    loadInitialMessages();
+  }, [roomId]);
+
+  // WebSocket 연결 및 실시간 메시지 수신
   useEffect(() => {
     const token = localStorage.getItem('token');
     if (token) {
       connectWebSocket(token);
     }
 
-    onMessage((msg: ChatMessagePayload) => {
+    const handleMessage = (msg: ChatMessagePayload) => {
       if (msg.chatType === ChatRoomType.GROUP && msg.roomId === roomId) {
-        setMessages((prev) => [...prev, msg]);
+        setMessages((prev) => [...prev, msg]); // 실시간 메시지 추가
       }
-    });
+    };
+
+    onMessage(handleMessage);
+
+    // 클린업 함수
+    return () => {
+      // onMessage 해제 로직이 있다면 호출
+      // 예: removeListener(handleMessage)
+    };
   }, [roomId]);
 
+  // 메시지 전송 함수
   const sendGroupMessage = (content: string) => {
     const userId = Number(localStorage.getItem('userId')); // 프론트에 저장된 userId를 사용
     if (!userId) return;


### PR DESCRIPTION
## 📌 작업 내용
- 그룹 채팅 메시지 목록 UI 구현 (`GroupChatMessageList`)
- 실시간 WebSocket 메시지 수신 처리 (`useGroupChat`)
- 초기 메시지 조회(fetch) 로직 `useGroupChat` 내부로 통합
- 날짜 구분선, 보낸 사람 구분 등 UI 표시 반영
- 메시지 전송 시 자동 스크롤 처리

## ✅ 완료된 로드맵 단계
- [x] 그룹 채팅 메시지 실시간 수신 처리
- [x] 초기 메시지 조회 통합
- [x] 메시지 리스트 UI 및 자동 스크롤

## 🔜 다음 작업 예정
- 그룹 채팅 입력창 UI 및 전송 처리 (`GroupChatInput`)
