### PR TITLE
[FE/FEAT] group chat - 그룹 채팅 입력창 구현 및 전송 기능 추가

### DIFF
--- a/fe/src/features/chat/group/components/GroupChatInput.module.css
+++ b/fe/src/features/chat/group/components/GroupChatInput.module.css
@@ -1,0 +1,36 @@
+.inputContainer {
+  display: flex;
+  gap: 8px;
+  padding: 12px;
+  border-top: 1px solid #ddd;
+  background-color: #fff;
+}
+
+.textInput {
+  flex: 1;
+  padding: 10px;
+  font-size: 14px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  background-color: white;
+}
+
+.textInput:disabled {
+  background-color: #f5f5f5;
+}
+
+.sendButton {
+  padding: 10px 16px;
+  background-color: #0070f3;
+  color: #fff;
+  font-weight: bold;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+.sendButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/fe/src/features/chat/group/components/GroupChatInput.tsx
+++ b/fe/src/features/chat/group/components/GroupChatInput.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useGroupChat } from '@/features/chat/group/services/useGroupChat';
+import styles from './GroupChatInput.module.css';
 
 interface GroupChatInputProps {
   roomId: number;
@@ -13,7 +14,7 @@ export default function GroupChatInput({ roomId }: GroupChatInputProps) {
   // [2] 중복 전송 방지용 상태
   const [isSending, setIsSending] = useState(false);
 
-  // [3] 그룹 채팅 메시지 전송 함수
+  // [3] 그룹 채팅 메시지 WebSocket 전송 함수
   const { sendGroupMessage } = useGroupChat(roomId);
 
   // [4] 전송 처리 함수
@@ -38,16 +39,7 @@ export default function GroupChatInput({ roomId }: GroupChatInputProps) {
 
   return (
     // [4] 채팅 입력 폼 렌더링
-    <form
-      onSubmit={handleSubmit}
-      style={{
-        display: 'flex',
-        gap: '8px',
-        padding: '12px',
-        borderTop: '1px solid #ddd', // 상단 구분선
-        backgroundColor: '#fff',
-      }}
-    >
+    <form onSubmit={handleSubmit} className={styles.inputContainer}>
       {/* [5] 입력창 */}
       <input
         type="text"
@@ -59,28 +51,12 @@ export default function GroupChatInput({ roomId }: GroupChatInputProps) {
           if (e.key === 'Enter' && !e.shiftKey) handleSubmit(e);
         }}
         disabled={isSending} // 전송 중 입력 비활성화
-        style={{
-          flex: 1,
-          padding: '10px',
-          border: '1px solid #ccc',
-          borderRadius: '6px',
-          fontSize: '14px',
-          backgroundColor: isSending ? '#f5f5f5' : 'white',
-        }}
       />
+      {/* 전송 버튼 구성 */}
       <button
         type="submit"
+        className={styles.sendButton}
         disabled={!content.trim() || isSending} // 전송 조건 및 중복 방지
-        style={{
-          padding: '10px 16px',
-          backgroundColor: '#0070f3',
-          color: '#fff',
-          border: 'none',
-          borderRadius: '6px',
-          cursor: 'pointer',
-          fontWeight: 'bold',
-          opacity: !content.trim() || isSending ? 0.6 : 1,
-        }}
       >
         전송
       </button>


### PR DESCRIPTION
## 💜 어떤 기능인가요?
- 그룹 채팅 입력창 UI 및 메시지 전송 기능을 구현했습니다.
- 사용자는 메시지를 입력 후 Enter 키 또는 전송 버튼을 눌러 메시지를 보낼 수 있습니다.

## ✅ 구현 내용
- `GroupChatInput.tsx` 생성
  - `useGroupChat().sendGroupMessage()`와 연동하여 WebSocket 메시지 전송
  - 입력 후 메시지 전송되면 입력창 초기화
  - 중복 전송 방지 위한 `isSending` 상태 처리
- `GroupChatInput.module.css` 분리
  - 입력창, 버튼 스타일 모듈화
  - 전송 중 상태일 때 비활성화 UI 처리

## 🔗 파일 경로
- `features/chat/group/components/GroupChatInput.tsx`
- `features/chat/group/components/GroupChatInput.module.css`

## 📌 완료된 로드맵 단계
- [x] 그룹 채팅 입력창 구현
- [x] 메시지 전송 처리
- [x] 전송 중 중복 방지
- [x] 스타일 분리 및 UI 통일

## 🔜 다음 작업 예정
- 채팅방 진입 시 포커싱 처리
- 입력창에서 Shift+Enter로 줄바꿈 가능하도록 개선 (선택)
