### PR TITLE
[FE/FEAT] GroupChatInput - 입력창 자동 포커싱 및 스타일 클래스 적용

### DIFF
--- a/fe/src/features/chat/group/components/GroupChatInput.tsx
+++ b/fe/src/features/chat/group/components/GroupChatInput.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useGroupChat } from '@/features/chat/group/services/useGroupChat';
 import styles from './GroupChatInput.module.css';
 
@@ -13,9 +13,14 @@ export default function GroupChatInput({ roomId }: GroupChatInputProps) {
   const [content, setContent] = useState('');
   // [2] 중복 전송 방지용 상태
   const [isSending, setIsSending] = useState(false);
-
   // [3] 그룹 채팅 메시지 WebSocket 전송 함수
   const { sendGroupMessage } = useGroupChat(roomId);
+  // 입력창 포커싱용 ref
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus(); // 마운트 시 자동 포커싱
+  }, []);
 
   // [4] 전송 처리 함수
   const handleSubmit = async (e: React.FormEvent | React.KeyboardEvent) => {
@@ -42,6 +47,7 @@ export default function GroupChatInput({ roomId }: GroupChatInputProps) {
     <form onSubmit={handleSubmit} className={styles.inputContainer}>
       {/* [5] 입력창 */}
       <input
+        ref={inputRef} // 입력창 포커싱 연결
         type="text"
         placeholder="메시지를 입력하세요"
         value={content}
@@ -51,6 +57,7 @@ export default function GroupChatInput({ roomId }: GroupChatInputProps) {
           if (e.key === 'Enter' && !e.shiftKey) handleSubmit(e);
         }}
         disabled={isSending} // 전송 중 입력 비활성화
+        className={styles.textInput}
       />
       {/* 전송 버튼 구성 */}
       <button


### PR DESCRIPTION
## 구현 내용
- 그룹 채팅 입력창(`GroupChatInput`)에 자동 포커싱 기능 추가
- 입력 필드에 `ref` 연결하여 마운트 시 `focus()` 처리
- 입력창에 `.textInput` 클래스 적용하여 CSS 모듈 스타일 연동

## 확인 사항
- 채팅 페이지 진입 시 입력창에 자동 커서 위치 확인
- 입력창 및 전송 버튼 스타일 정상 적용 여부 확인

## 관련 이슈
#92-6 그룹 채팅 입력창 입력 UX 개선
