### PR TITLE
[FE/FEAT] DMChatInput - DM 메시지 전송 기능 WebSocket 연동 및 UI 개선

### DIFF
--- a/fe/src/features/chat/dm/components/DmChatInput.module.css
+++ b/fe/src/features/chat/dm/components/DmChatInput.module.css
@@ -1,0 +1,36 @@
+.inputContainer {
+  display: flex;
+  gap: 8px;
+  padding: 12px;
+  border-top: 1px solid #ddd;
+  background-color: #fff;
+}
+
+.textInput {
+  flex: 1;
+  padding: 10px;
+  font-size: 14px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  background-color: white;
+}
+
+.textInput:disabled {
+  background-color: #f5f5f5;
+}
+
+.sendButton {
+  padding: 10px 16px;
+  background-color: #0070f3;
+  color: #fff;
+  font-weight: bold;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+.sendButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/fe/src/features/chat/dm/components/DmChatInput.tsx
+++ b/fe/src/features/chat/dm/components/DmChatInput.tsx
@@ -1,31 +1,59 @@
 'use client';
 
 import { useState } from 'react';
+import { useDmChat } from '@/features/chat/dm/services/useDmChat';
+import styles from './DmChatInput.module.css';
 
 interface DmChatInputProps {
-  onSend: (content: string) => void;
+  roomId: number; // roomId, receiverId props로 받음
+  receiverId: number;
 }
 
-export default function DmChatInput({ onSend }: DmChatInputProps) {
+export default function DmChatInput({ roomId, receiverId }: DmChatInputProps) {
   const [content, setContent] = useState('');
+  const [isSending, setIsSending] = useState(false);
 
-  const handleSend = () => {
-    if (content.trim() === '') return;
-    onSend(content);
-    setContent('');
+  const { sendDmMessage } = useDmChat(roomId, receiverId);
+
+  const handleSubmit = async (e: React.FormEvent | React.KeyboardEvent) => {
+    e.preventDefault(); // 기본 submit 막기
+
+    if (!content.trim() || isSending) return; // 빈 메시지 or 중복 전송 방지
+
+    try {
+      setIsSending(true);
+      await sendDmMessage(content); // WebSocket 전송
+      setContent('');
+    } catch (err) {
+      console.error('DM 메시지 전송 실패:', err);
+      alert('메시지 전송에 실패했습니다.');
+    } finally {
+      setIsSending(false);
+    }
   };
 
   return (
-    <div>
+    <form onSubmit={handleSubmit} className={styles.inputContainer}>
+      {' '}
+      {/* [수정] - form으로 변경 */}
       <input
+        type="text"
+        placeholder="메시지를 입력하세요"
         value={content}
         onChange={(e) => setContent(e.target.value)}
         onKeyDown={(e) => {
-          if (e.key === 'Enter') handleSend();
+          if (e.key === 'Enter' && !e.shiftKey) handleSubmit(e); // [수정] - Enter로 전송
         }}
-        placeholder="메시지를 입력하세요"
+        disabled={isSending} // [수정]
+        className={styles.textInput} // [유지]
       />
-      <button onClick={handleSend}>전송</button>
-    </div>
+      <button
+        type="submit"
+        disabled={!content.trim() || isSending} // [유지]
+        className={styles.sendButton} // [유지]
+      >
+        전송
+      </button>
+    </form>
   );
 }


### PR DESCRIPTION
## ✅ DMChatInput 기능 구현

- `useDmChat` 훅 사용해 WebSocket 기반 DM 메시지 전송 기능 연결
- `roomId` / `receiverId props` 직접 전달 방식으로 구조 개선
- `isSending` 상태로 중복 전송 방지 처리
- Enter 키 전송 / Shift+Enter 예외 처리
- 기존 CSS 모듈 스타일 적용 유지

### 📁 변경 파일
- `DmChatInput.tsx`
- `DmChatInput.module.css`  : 파일 추가
