### PR TITLE
[FE/FEAT] DM 채팅방 목록 - 요약 정보 조회 UI/기능 구현

### DIFF
--- a/fe/src/features/chat/dm/components/DmChatRoomList.module.css
+++ b/fe/src/features/chat/dm/components/DmChatRoomList.module.css
@@ -1,0 +1,53 @@
+.container {
+  padding: 16px;
+}
+
+.title {
+  font-size: 20px;
+  font-weight: bold;
+  margin-bottom: 16px;
+}
+
+.empty {
+  color: #777;
+  font-size: 14px;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.item {
+  padding: 12px;
+  margin-bottom: 12px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.read {
+  background-color: #f9f9f9;
+}
+
+.unread {
+  background-color: #fff7e6;
+}
+
+.nickname {
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+
+.message {
+  font-size: 14px;
+  color: #333;
+}
+
+.unreadCount {
+  margin-top: 6px;
+  color: red;
+  font-weight: bold;
+}

--- a/fe/src/features/chat/dm/components/DmChatRoomList.tsx
+++ b/fe/src/features/chat/dm/components/DmChatRoomList.tsx
@@ -1,43 +1,49 @@
 'use client';
 
 import { useDmChatRoomList } from '@/features/chat/dm/services/useDmChatRoomList';
-import { DmChatRoomSummary } from '@/features/chat/dm/types/DmChatRoomSummary';
 import { useRouter } from 'next/navigation';
+import styles from './DmChatRoomList.module.css';
+
+// 시간 포맷 함수 분리
+function formatTime(isoString: string) {
+  if (!isoString) return '';
+  return new Date(isoString).toLocaleString('ko-KR', {
+    year: '2-digit',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
 
 export default function DmChatRoomList() {
   const { rooms } = useDmChatRoomList();
   const router = useRouter();
 
   return (
-    <div style={{ padding: '16px' }}>
-      <h2>DM 채팅방 목록</h2>
+    <div className={styles.container}>
+      {' '}
+      {/* 인라인 → className */}
+      <h2 className={styles.title}>DM 채팅방 목록</h2>
       {rooms.length === 0 ? (
-        <div>채팅방이 없습니다.</div>
+        <div className={styles.empty}>채팅방이 없습니다.</div>
       ) : (
-        <ul style={{ listStyle: 'none', padding: 0 }}>
-          {rooms.map((room: DmChatRoomSummary, idx: number) => (
+        <ul className={styles.list}>
+          {rooms.map((room) => (
             <li
-              key={idx}
-              onClick={() => router.push(`/chat-detail/dm/${room.roomId}`)} // router.push 사용으로 이동
-              style={{
-                padding: '12px',
-                marginBottom: '12px',
-                border: '1px solid #ccc',
-                borderRadius: '8px',
-                cursor: 'pointer',
-                background: room.unreadCount > 0 ? '#fff7e6' : '#f9f9f9', // 안 읽은 메시지 색상 강조
-              }}
+              key={room.roomId} // idx 대신 고유 ID 사용
+              onClick={() => router.push(`/chat-detail/dm/${room.roomId}`)}
+              className={`${styles.item} ${
+                room.unreadCount > 0 ? styles.unread : styles.read
+              }`} // 읽음 여부에 따라 동적 클래스 적용
             >
-              <div style={{ fontWeight: 'bold' }}>{room.opponentNickname}</div>
-              <div>
-                {/* 메시지 형식 구분 */}
-                {room.format === 'ARCHIVE' ? '[자료]' : room.previewMessage}
-                {' | '}
-                {room.sentAt?.slice(0, 16).replace('T', ' ')}
+              <div className={styles.nickname}>{room.opponentNickname}</div>
+              <div className={styles.message}>
+                {room.format === 'ARCHIVE' ? '[자료]' : room.previewMessage} |{' '}
+                {formatTime(room.sentAt)}
               </div>
-              {/* 안 읽은 메시지 수 강조 */}
               {room.unreadCount > 0 && (
-                <div style={{ color: 'red' }}>
+                <div className={styles.unreadCount}>
                   안 읽은 메시지 {room.unreadCount}개
                 </div>
               )}

--- a/fe/src/features/chat/dm/services/useDmChatRoomList.ts
+++ b/fe/src/features/chat/dm/services/useDmChatRoomList.ts
@@ -1,19 +1,38 @@
+'use client';
+
 import { useEffect, useState } from 'react';
-import { apiClient } from '@/lib/api/apiClient';
 import { DmChatRoomSummary } from '../types/DmChatRoomSummary';
 
 export function useDmChatRoomList() {
+  // 상태 정의
   const [rooms, setRooms] = useState<DmChatRoomSummary[]>([]);
+  const [loading, setLoading] = useState(true); // 로딩 여부 표시용
 
   useEffect(() => {
     const fetchRooms = async () => {
-      const data = await apiClient<DmChatRoomSummary[]>(
-        '/api/v1/dm-chat/summary'
-      );
-      setRooms(data);
-    };
-    fetchRooms();
-  }, []);
+      try {
+        // fetch 직접 호출 + Authorization 헤더 명시
+        const res = await fetch('/api/v1/dm-chat/summary', {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem('token')}`, // 토큰 인증 추가
+          },
+        });
 
-  return { rooms };
+        if (!res.ok) throw new Error('채팅방 요약 정보를 불러오지 못했습니다'); // 오류 핸들링 추가
+
+        const data = await res.json(); // 응답 파싱
+        setRooms(data); // 성공 시 상태 반영
+      } catch (err) {
+        console.error(err); // 오류 로그 출력
+        setRooms([]); // 실패 시 rooms 초기화
+      } finally {
+        setLoading(false); // 로딩 종료
+      }
+    };
+
+    fetchRooms(); // 컴포넌트 마운트 시 데이터 불러오기
+  }, []); // 최초 1회 실행
+
+  return { rooms, loading }; // 로딩 상태 포함 반환
 }


### PR DESCRIPTION
## 구현 내용
- DM 채팅방 목록(`DmChatRoomList`) 컴포넌트 구현
- `useDmChatRoomList` 훅을 통해 요약 정보 fetch
- 목록 항목 클릭 시 해당 채팅방으로 이동
- 읽음 여부(`unreadCount`)에 따른 스타일 분기 처리
- 시각 포맷 함수 `formatTime` 분리 적용
- 스타일 모듈 `DmChatRoomList.module.css` 작성 및 적용

## 기타
- 타입 추론 기반으로 map 내부에서 타입 생략
- 향후 스켈레톤/로딩 처리, 무한 스크롤 등 추가 가능
