### PR TITLE
[FE/FEAT] DM 채팅방 상세 - 메시지 목록 조회 기능 구현

### DIFF
--- a/fe/src/features/chat/dm/services/fetchDmChatMessages.ts
+++ b/fe/src/features/chat/dm/services/fetchDmChatMessages.ts
@@ -1,0 +1,12 @@
+// DM 채팅방 메시지 목록 불러오기 함수
+import { ChatMessagePayload } from '@/features/chat/common/types/ChatMessagePayload';
+import { apiClient } from '@/lib/api/apiClient';
+
+export async function fetchDmChatMessages(
+  roomId: number
+): Promise<ChatMessagePayload[]> {
+  // GET 요청으로 해당 roomId의 DM 메시지 조회
+  return await apiClient<ChatMessagePayload[]>(
+    `/api/v1/dm-chat/messages/${roomId}`
+  );
+}

--- a/fe/src/features/chat/dm/services/useDmChat.ts
+++ b/fe/src/features/chat/dm/services/useDmChat.ts
@@ -5,10 +5,29 @@ import { connectWebSocket, sendMessage, onMessage } from '@/lib/socket';
 import { ChatMessagePayload } from '@/features/chat/common/types/ChatMessagePayload';
 import { ChatRoomType } from '@/features/chat/common/types/ChatRoomType';
 import { MessageFormat } from '@/features/chat/common/types/MessageFormat';
+import { fetchDmChatMessages } from './fetchDmChatMessages'; // 과거 메시지 fetch 함수
 
 export function useDmChat(roomId: number, receiverId: number | null) {
-  const [messages, setMessages] = useState<ChatMessagePayload[]>([]);
+  const [messages, setMessages] = useState<ChatMessagePayload[]>([]); // 과거 + 실시간 메시지 포함
 
+  // senderId를 localStorage에서 가져오도록 변경 예정
+  const userId = Number(localStorage.getItem('userId')); // 인증 연동 시 이 부분은 추상화된 유저 훅으로 대체 가능
+
+  // 초기에 과거 메시지 불러오기
+  useEffect(() => {
+    const loadMessages = async () => {
+      try {
+        const pastMessages = await fetchDmChatMessages(roomId);
+        setMessages(pastMessages); // 과거 메시지 저장
+      } catch (error) {
+        console.error('과거 메시지 불러오기 실패:', error);
+      }
+    };
+
+    loadMessages();
+  }, [roomId]);
+
+  // 실시간 메시지 수신 처리
   useEffect(() => {
     // websocket 연결
     const token = localStorage.getItem('token');
@@ -36,7 +55,7 @@ export function useDmChat(roomId: number, receiverId: number | null) {
     const payload: ChatMessagePayload = {
       roomId,
       receiverId,
-      senderId: 1, // 후속 단계에서 auth에서 가져올 예정
+      senderId: userId, // localStorage에서 가져온 값 사용
       content,
       format: MessageFormat.TEXT,
       chatType: ChatRoomType.DIRECT,


### PR DESCRIPTION
### 📌 기능 개요
- 사용자가 `/chat-detail/dm/:roomId` 경로 진입 시,
   - 과거 메시지를 API(`fetchDmChatMessages`)로 불러오고
   - `useDmChat` 훅을 통해 WebSocket으로 실시간 메시지까지 통합 관리
   - `DmChatMessageList` 컴포넌트에서 메시지 목록 출력 (날짜 구분선 및 시각 포함)

### ✅ 구현 상세
- `fetchDmChatMessages`: 과거 메시지 조회 API 호출 함수
- `useDmChat`: 초기 메시지 불러오고, 실시간 수신 메시지 병합
- `DmChatMessageList`: 내 메시지/상대 메시지 분기, 시간 포맷, 날짜 구분선 출력

### 🧪 테스트
- 과거 + 실시간 메시지가 정상적으로 합쳐져 출력됨
- 자동 스크롤, 날짜 구분, 시간 포맷, 본인/상대 메시지 색상 분기 정상 작동