### PR TITLE
[FE/FEAT] 자료방 기능 - 자료 목록 조회 및 태그 필터링 기능 구현

### DIFF
--- a/fe/src/features/chat/archive/components/ArchiveFileList.tsx
+++ b/fe/src/features/chat/archive/components/ArchiveFileList.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useArchive } from '@/features/chat/archive/services/useArchive';
+import ArchiveTagFilter from './ArchiveTagFilter';
+import styles from './ArchiveFileList.module.css';
+
+export default function ArchiveFileList({ roomId }: { roomId: number }) {
+  const { archiveItems, fetchItems } = useArchive(roomId); // 자료 목록과 fetch 함수 불러오기
+  const [selectedTag, setSelectedTag] = useState<string | null>(null); // 선택된 태그 상태
+
+  useEffect(() => {
+    fetchItems(); // 진입 시 자료 메시지 목록 불러오기
+  }, [fetchItems]);
+
+  // 전체 자료에서 태그 목록 추출
+  const allTags = Array.from(
+    new Set(archiveItems.flatMap((item) => item.tags.map((tag) => tag.name)))
+  );
+
+  // 선택된 태그에 따른 필터링
+  const filteredItems = selectedTag
+    ? archiveItems.filter((item) =>
+        item.tags.some((tag) => tag.name === selectedTag)
+      )
+    : archiveItems;
+
+  return (
+    <div className={styles.archiveList}>
+      {/* 태그 필터 UI */}
+      <ArchiveTagFilter
+        tags={allTags}
+        selectedTag={selectedTag}
+        onSelect={setSelectedTag}
+      />
+
+      {filteredItems.length === 0 ? (
+        <p className={styles.empty}>등록된 자료가 없습니다.</p>
+      ) : (
+        <ul className={styles.list}>
+          {filteredItems.map((item) => (
+            <li key={item.id} className={styles.item}>
+              <div className={styles.filename}>{item.originalFilename}</div>
+              <div className={styles.meta}>
+                <span className={styles.uploader}>
+                  업로더: {item.uploaderNickname}
+                </span>
+                <span className={styles.createdAt}>
+                  {new Date(item.createdAt).toLocaleString('ko-KR')}
+                </span>
+              </div>
+              <div className={styles.tags}>
+                {item.tags.map((tag) => (
+                  <span key={tag.id} className={styles.tag}>
+                    #{tag.name}
+                  </span>
+                ))}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/fe/src/features/chat/archive/components/ArchiveTagFilter.module.css
+++ b/fe/src/features/chat/archive/components/ArchiveTagFilter.module.css
@@ -1,0 +1,25 @@
+.tagFilter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 12px;
+  border-bottom: 1px solid #eee;
+}
+
+.tagButton {
+  padding: 6px 12px;
+  background-color: #f5f5f5;
+  border: none;
+  border-radius: 20px;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.tagButton:hover {
+  background-color: #e6f7ff;
+}
+
+.active {
+  background-color: #bae7ff;
+  font-weight: bold;
+}

--- a/fe/src/features/chat/archive/components/ArchiveTagFilter.tsx
+++ b/fe/src/features/chat/archive/components/ArchiveTagFilter.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import styles from './ArchiveTagFilter.module.css';
+
+interface ArchiveTagFilterProps {
+  tags: string[]; // 모든 태그 목록
+  selectedTag: string | null;
+  onSelect: (tag: string | null) => void;
+}
+
+export default function ArchiveTagFilter({
+  tags,
+  selectedTag,
+  onSelect,
+}: ArchiveTagFilterProps) {
+  return (
+    <div className={styles.tagFilter}>
+      <button
+        className={`${styles.tagButton} ${
+          selectedTag === null ? styles.active : ''
+        }`}
+        onClick={() => onSelect(null)}
+      >
+        전체
+      </button>
+      {tags.map((tag) => (
+        <button
+          key={tag}
+          className={`${styles.tagButton} ${
+            selectedTag === tag ? styles.active : ''
+          }`}
+          onClick={() => onSelect(tag)}
+        >
+          #{tag}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/fe/src/features/chat/archive/services/fetchArchiveItems.ts
+++ b/fe/src/features/chat/archive/services/fetchArchiveItems.ts
@@ -1,0 +1,15 @@
+// 자료 메시지 목록 조회 API
+import { apiClient } from '@/lib/api/apiClient';
+import { ArchiveItem } from '@/features/chat/archive/types/ArchiveItem';
+
+export async function fetchArchiveItems(
+  roomId: number
+): Promise<ArchiveItem[]> {
+  try {
+    const res = await apiClient<ArchiveItem[]>(`/api/v1/archive/${roomId}`);
+    return res;
+  } catch (err) {
+    console.error('📂 자료 불러오기 실패:', err);
+    return [];
+  }
+}

--- a/fe/src/features/chat/archive/types/ArchiveItem.ts
+++ b/fe/src/features/chat/archive/types/ArchiveItem.ts
@@ -1,0 +1,13 @@
+// 자료방에서 사용하는 파일 항목 타입
+
+import { ArchiveTag } from './ArchiveTag'; // 자료에 연결된 태그 타입
+
+export interface ArchiveItem {
+  id: number; // 자료 ID
+  originalFilename: string; // 사용자가 업로드한 원래 파일 이름
+  storedFilename: string; // 서버에 저장된 파일 이름 (S3 key 등)
+  url: string; // 다운로드/미리보기 가능한 URL
+  createdAt: string; // 업로드 시각 (ISO 8601 문자열)
+  uploaderNickname: string; // 업로드한 사용자 닉네임
+  tags: ArchiveTag[]; // 연결된 태그 목록
+}

--- a/fe/src/features/chat/archive/types/ArchiveTag.ts
+++ b/fe/src/features/chat/archive/types/ArchiveTag.ts
@@ -1,0 +1,6 @@
+// 자료방에서 사용하는 태그 타입
+
+export interface ArchiveTag {
+  id: number; // 태그 고유 ID
+  name: string; // 태그 이름 (예: "사후르", "기획안", "촬영자료")
+}

--- a/fe/src/features/chat/archive/types/ArchiveUploadRequest.ts
+++ b/fe/src/features/chat/archive/types/ArchiveUploadRequest.ts
@@ -1,0 +1,12 @@
+// 자료 메시지 업로드 요청 DTO
+
+import { MessageFormat } from '@/features/chat/common/types/MessageFormat';
+
+export interface ArchiveUploadRequest {
+  roomId: number; // 채팅방 ID
+  senderId: number; // 보낸 사람 ID (나중에 auth에서 추출 예정)
+  content: string; // 자료 설명 또는 파일명 (태그 포함 가능)
+  format: MessageFormat; // 메시지 형식 (ARCHIVE로 고정)
+  tagNames: string[]; // 태그 이름 목록 (예: ['사후르', '기획안'])
+  createdAt: string; // 전송 시각 (ISO 문자열)
+}


### PR DESCRIPTION
## 💜 어떤 기능인가요?
- 팀/프로젝트 채팅방 내 자료방 탭 진입 시 자료 목록을 조회하고
- 태그 기반으로 자료를 필터링하는 기능

## ✅ 구현 내역
- `useArchive.ts`: `roomId`에 따라 자료 API 호출 및 상태 관리 훅 구현
- `ArchiveFileList.tsx`: 자료 목록 렌더링 + 태그 필터링 처리
- `ArchiveTagFilter.tsx`: 태그 UI 클릭 시 필터링 상태 업데이트
- 관련 스타일 `ArchiveFileList.module.css` 적용
- 타입 및 API 오류 수정 (`ChatMessagePayload[] → ArchiveItem[]`, `useState` import 누락 등)

## 📎 연관 이슈
- #199
