### PR TITLE
[FE/BE/FEAT] 아카이브 태그 입력 및 메시지 전송 기능 구현

### DIFF
--- a/be/src/main/java/com/example/mingle/domain/chat/archive/controller/ApiV1ArchiveItemController.java
+++ b/be/src/main/java/com/example/mingle/domain/chat/archive/controller/ApiV1ArchiveItemController.java
@@ -24,9 +24,9 @@ public class ApiV1ArchiveItemController {
 
     // 1. 자료 업로드
     @PostMapping
-    public ResponseEntity<String> upload(@ModelAttribute ArchiveUploadRequest request) throws IOException {
-        archiveUploadService.upload(request);
-        return ResponseEntity.ok("업로드 완료");
+    public ResponseEntity<ArchiveItemResponse> upload(@ModelAttribute ArchiveUploadRequest request) throws IOException {
+        ArchiveItemResponse response = archiveUploadService.upload(request); // 서비스 리턴 타입 수정
+        return ResponseEntity.ok(response);
     }
 
     // 2. 채팅방 ID 기준 전체 자료 조회

--- a/be/src/main/java/com/example/mingle/domain/chat/archive/service/ArchiveUploadService.java
+++ b/be/src/main/java/com/example/mingle/domain/chat/archive/service/ArchiveUploadService.java
@@ -1,5 +1,6 @@
 package com.example.mingle.domain.chat.archive.service;
 
+import com.example.mingle.domain.chat.archive.dto.ArchiveItemResponse;
 import com.example.mingle.domain.chat.archive.dto.ArchiveUploadRequest;
 
 import java.util.List;
@@ -8,7 +9,7 @@ import java.io.IOException;
 public interface ArchiveUploadService {
 
     // 실제 파일 업로드 + 태그 저장
-    void upload(ArchiveUploadRequest request) throws IOException;
+    ArchiveItemResponse upload(ArchiveUploadRequest request) throws IOException;
 
     // 태그 수정용 메서드
     void updateTags(Long archiveItemId, List<String> tags);

--- a/be/src/main/java/com/example/mingle/domain/chat/archive/service/ArchiveUploadServiceImpl.java
+++ b/be/src/main/java/com/example/mingle/domain/chat/archive/service/ArchiveUploadServiceImpl.java
@@ -1,6 +1,7 @@
 package com.example.mingle.domain.chat.archive.service;
 
 import com.example.mingle.domain.chat.archive.dto.ArchiveUploadRequest;
+import com.example.mingle.domain.chat.archive.dto.ArchiveItemResponse;
 import com.example.mingle.domain.chat.archive.entity.ArchiveItem;
 import com.example.mingle.domain.chat.archive.entity.ArchiveTag;
 import com.example.mingle.domain.chat.archive.repository.ArchiveItemRepository;
@@ -31,7 +32,7 @@ public class ArchiveUploadServiceImpl implements ArchiveUploadService {
     private final AwsS3Uploader awsS3Uploader;
 
     @Override
-    public void upload(ArchiveUploadRequest request) throws IOException {
+    public ArchiveItemResponse upload(ArchiveUploadRequest request) throws IOException {
 
         // 1. S3에 업로드
         String fileUrl = awsS3Uploader.upload(request.file(), "archive_files");
@@ -76,6 +77,8 @@ public class ArchiveUploadServiceImpl implements ArchiveUploadService {
 
         // 5. 저장
         archiveItemRepository.save(archiveItem);
+
+        return ArchiveItemResponse.from(archiveItem); // 저장된 결과를 응답 객체로 변환하여 반환
     }
 
 

--- a/fe/src/app/(auth)/login/page.tsx
+++ b/fe/src/app/(auth)/login/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import LoginForm from '@/features/auth/components/LoginForm';
+import LoginForm from '@/features/user/auth/components/LoginForm';
 
 export default function LoginPage() {
   return (

--- a/fe/src/features/chat/archive/components/ArchiveUploadForm.tsx
+++ b/fe/src/features/chat/archive/components/ArchiveUploadForm.tsx
@@ -3,8 +3,10 @@
 import { useState } from 'react';
 import { uploadArchiveItem } from '@/features/chat/archive/services/uploadArchiveItem';
 import { useArchive } from '@/features/chat/archive/services/useArchive';
+import { useTagAutocomplete } from '@/features/chat/archive/services/useTagAutocomplete';
+import type { ArchiveItemResponse } from '@/features/chat/archive/types/ArchiveItemResponse';
 import { extractTagsFromFilename } from '@/features/chat/common/utils/chatUtils';
-import { sendMessage } from '@/lib/socket';
+import { useSocket } from '@/hooks/useSocket';
 import { MessageFormat } from '@/features/chat/common/types/MessageFormat';
 import { ChatRoomType } from '@/features/chat/common/types/ChatRoomType';
 
@@ -14,49 +16,133 @@ interface ArchiveUploadFormProps {
 
 export default function ArchiveUploadForm({ roomId }: ArchiveUploadFormProps) {
   const [file, setFile] = useState<File | null>(null);
+  const [tags, setTags] = useState<string[]>([]); // 유저가 직접 입력하는 태그 상태
+  const [isUploading, setIsUploading] = useState(false); // 업로드 중 여부 상태
+  const [currentInput, setCurrentInput] = useState(''); // 자동완성 검색어 상태
+
+  const { suggestions } = useTagAutocomplete(currentInput); // 자동완성 hook 사용
   const { fetchItems } = useArchive(roomId);
+  const token = localStorage.getItem('token')!; // 토큰 가져오기
+  const { send } = useSocket(token, () => {}); // 메시지 전송용 useSocket 훅 사용
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = e.target.files?.[0] || null;
+    setFile(selected); // 기존 onChange 로직을 별도 함수로 분리
+    if (selected) {
+      const extracted = extractTagsFromFilename(selected.name); // 자동 태그 추출
+      setTags(extracted); // 자동 추출 태그 저장
+    }
+  };
 
   const handleUpload = async () => {
-    if (!file) return;
+    if (!file || isUploading) return; // 중복 업로드 방지
+    setIsUploading(true); // 업로드 시작
 
-    const tags = extractTagsFromFilename(file.name);
     const formData = new FormData();
     formData.append('file', file);
     formData.append('roomId', String(roomId));
     tags.forEach((tag) => formData.append('tags', tag));
 
     try {
-      await uploadArchiveItem({
+      // 업로드 후 반환값 받기
+      const uploaded: ArchiveItemResponse = await uploadArchiveItem({
         roomId,
         file,
         uploaderId: Number(localStorage.getItem('userId')),
         chatType: ChatRoomType.GROUP,
       });
+
       fetchItems(); // 자료 목록 갱신
 
-      sendMessage({
+      // 업로드된 값 기반으로 메시지 전송
+      send({
         roomId,
         senderId: Number(localStorage.getItem('userId')), // 향후 auth 적용
         chatType: ChatRoomType.GROUP,
         format: MessageFormat.ARCHIVE,
-        content: file.name,
-        createdAt: new Date().toISOString(),
+        content: uploaded.fileName,
+        createdAt: uploaded.createdAt,
+        tagNames: uploaded.tags,
       });
+
       setFile(null);
+      setTags([]); // 업로드 후 태그 초기화
+      setCurrentInput(''); // 입력 초기화
     } catch (err) {
-      alert('업로드 실패');
+      alert('업로드에 실패했어요. 다시 시도해주세요.');
       console.error(err);
+    } finally {
+      setIsUploading(false); // 업로드 종료
     }
   };
 
   return (
     <div>
+      <input type="file" onChange={handleFileChange} />
+
       <input
-        type="file"
-        onChange={(e) => setFile(e.target.files?.[0] || null)}
+        type="text"
+        placeholder="태그를 입력하고 Enter"
+        value={currentInput}
+        onChange={(e) => setCurrentInput(e.target.value)}
+        onKeyDown={(e) => {
+          const value = currentInput.trim();
+          if ((e.key === 'Enter' || e.key === ',') && value) {
+            e.preventDefault(); // 쉼표와 엔터 모두 처리
+            if (!tags.includes(value)) {
+              setTags([...tags, value]); // 중복 태그 방지
+            }
+            setCurrentInput('');
+          }
+        }}
       />
-      <button onClick={handleUpload} disabled={!file}>
-        업로드
+
+      {/* 자동완성 리스트 UI */}
+      {currentInput && suggestions.length > 0 && (
+        <ul
+          style={{
+            listStyle: 'none',
+            padding: '4px 8px',
+            border: '1px solid #ccc',
+            backgroundColor: '#fff',
+            maxHeight: '120px',
+            overflowY: 'auto',
+            marginBottom: '8px',
+          }}
+        >
+          {suggestions.map((tag) => (
+            <li
+              key={tag}
+              style={{ cursor: 'pointer', padding: '4px 0' }}
+              onClick={() => {
+                if (!tags.includes(tag)) {
+                  setTags([...tags, tag]);
+                }
+                setCurrentInput('');
+              }}
+            >
+              #{tag}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div style={{ marginTop: '8px' }}>
+        {tags.map((tag) => (
+          <span key={tag} style={{ marginRight: '6px' }}>
+            #{tag}{' '}
+            <button
+              type="button"
+              onClick={() => setTags(tags.filter((t) => t !== tag))}
+            >
+              ❌
+            </button>
+          </span>
+        ))}
+      </div>
+
+      <button onClick={handleUpload} disabled={!file || isUploading}>
+        {isUploading ? '업로드 중...' : '업로드'}
       </button>
     </div>
   );

--- a/fe/src/features/chat/archive/services/uploadArchiveItem.ts
+++ b/fe/src/features/chat/archive/services/uploadArchiveItem.ts
@@ -3,6 +3,7 @@
 import { uploadClient } from '@/lib/api/uploadClient'; // 새로 만든 업로드 전용 client
 import { ChatRoomType } from '@/features/chat/common/types/ChatRoomType';
 import { MessageFormat } from '@/features/chat/common/types/MessageFormat';
+import type { ArchiveItemResponse } from '@/features/chat/archive/types/ArchiveItemResponse';
 
 interface UploadArchiveParams {
   roomId: number;
@@ -16,7 +17,7 @@ export async function uploadArchiveItem({
   file,
   uploaderId,
   chatType,
-}: UploadArchiveParams) {
+}: UploadArchiveParams): Promise<ArchiveItemResponse> {
   const formData = new FormData();
 
   formData.append('file', file);

--- a/fe/src/features/chat/archive/services/useTagAutocomplete.ts
+++ b/fe/src/features/chat/archive/services/useTagAutocomplete.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export function useTagAutocomplete(input: string) {
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!input) return setSuggestions([]);
+
+    const fetchSuggestions = async () => {
+      try {
+        setLoading(true);
+        const res = await fetch(`/api/v1/archive/tags/search?prefix=${input}`);
+        const data = await res.json();
+        setSuggestions(data);
+      } catch (err) {
+        console.error('태그 추천 실패:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    const timeoutId = setTimeout(fetchSuggestions, 200); // ⏱ debounce
+    return () => clearTimeout(timeoutId);
+  }, [input]);
+
+  return { suggestions, loading };
+}

--- a/fe/src/features/chat/archive/types/ArchiveItemResponse.ts
+++ b/fe/src/features/chat/archive/types/ArchiveItemResponse.ts
@@ -1,0 +1,11 @@
+// 서버의 ArchiveItemResponse DTO에 대응하는 프론트 타입
+
+export interface ArchiveItemResponse {
+  id: number;
+  fileUrl: string;
+  fileName: string;
+  thumbnailUrl: string | null;
+  tags: string[];
+  uploaderNickname: string;
+  createdAt: string; // ISO 8601 형식 문자열
+}

--- a/fe/src/features/chat/common/types/ChatMessagePayload.ts
+++ b/fe/src/features/chat/common/types/ChatMessagePayload.ts
@@ -8,4 +8,5 @@ export interface ChatMessagePayload {
   format: MessageFormat; // TEXT, ARCHIVE, etc
   chatType: ChatRoomType; // 'dm' | 'group'
   createdAt: string; //
+  tagNames?: string[];
 }

--- a/fe/src/features/chat/dm/components/DmChatMessageList.tsx
+++ b/fe/src/features/chat/dm/components/DmChatMessageList.tsx
@@ -1,24 +1,18 @@
 'use client';
 
-import styles from './DmChatMessageList.module.css';
 import { useEffect, useRef } from 'react';
 import { useDmChat } from '@/features/chat/dm/services/useDmChat';
 import { ChatMessagePayload } from '@/features/chat/common/types/ChatMessagePayload';
-
+import { MessageFormat } from '@/features/chat/common/types/MessageFormat';
+import {
+  getDateString,
+  getTimeString,
+} from '@/features/chat/common/utils/dateUtils';
+import styles from './DmChatMessageList.module.css';
 interface DmChatMessageListProps {
   roomId: number;
   receiverId: number;
 }
-
-// 날짜 추출 유틸
-const getDateString = (dateStr: string) => dateStr.split('T')[0];
-
-// 시간 포맷 유틸
-const getTimeString = (dateStr: string) =>
-  new Date(dateStr).toLocaleTimeString('ko-KR', {
-    hour: '2-digit',
-    minute: '2-digit',
-  });
 
 export default function DmChatMessageList({
   roomId,
@@ -81,7 +75,41 @@ export default function DmChatMessageList({
                 {isMe ? '나' : `상대(${msg.senderId})`}
               </div>
 
-              <div className={styles.messageText}>{msg.content}</div>
+              {/* 메시지 포맷 분기 처리 */}
+              <div className={styles.messageText}>
+                {msg.format === MessageFormat.ARCHIVE ? (
+                  <>
+                    <a
+                      href={msg.content}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{ color: '#1890ff', textDecoration: 'underline' }}
+                    >
+                      📎 {msg.content.split('/').pop()} {/* 파일명만 출력 */}
+                    </a>
+
+                    {/* 태그 정보 표시 */}
+                    {!!msg.tagNames && msg.tagNames.length > 0 && (
+                      <div
+                        style={{
+                          marginTop: '4px',
+                          fontSize: '12px',
+                          color: '#999',
+                        }}
+                      >
+                        {msg.tagNames.map((tag) => (
+                          <span key={tag} style={{ marginRight: '6px' }}>
+                            #{tag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  msg.content
+                )}
+              </div>
+
               <div className={styles.timeStamp}>
                 {getTimeString(msg.createdAt)}
               </div>

--- a/fe/src/features/chat/group/components/GroupChatMessageList.tsx
+++ b/fe/src/features/chat/group/components/GroupChatMessageList.tsx
@@ -3,20 +3,15 @@
 import { useEffect, useRef } from 'react';
 import { useGroupChat } from '@/features/chat/group/services/useGroupChat';
 import { ChatMessagePayload } from '@/features/chat/common/types/ChatMessagePayload';
+import { MessageFormat } from '@/features/chat/common/types/MessageFormat';
+import {
+  getDateString,
+  getTimeString,
+} from '@/features/chat/common/utils/dateUtils';
 import styles from './GroupChatMessageList.module.css';
 interface GroupChatMessageListProps {
   roomId: number;
 }
-
-// 날짜 문자열 추출 유틸
-const getDateString = (dateStr: string) => dateStr.split('T')[0];
-
-// 시각 포맷 유틸
-const getTimeString = (dateStr: string) =>
-  new Date(dateStr).toLocaleTimeString('ko-KR', {
-    hour: '2-digit',
-    minute: '2-digit',
-  });
 
 export default function GroupChatMessageList({
   roomId,
@@ -36,7 +31,7 @@ export default function GroupChatMessageList({
         const isMe = msg.senderId === currentUserId;
         const dateStr = getDateString(msg.createdAt);
         const showDateDivider =
-          idx === 0 || dateStr !== getDateString(messages[idx - 1].createdAt); // 🔧 [수정] allMessages → messages
+          idx === 0 || dateStr !== getDateString(messages[idx - 1].createdAt);
 
         return (
           <div key={`${msg.createdAt}-${msg.senderId}-${idx}`}>
@@ -61,7 +56,43 @@ export default function GroupChatMessageList({
               <div className={styles.senderLabel}>
                 {isMe ? '나' : `사용자 ${msg.senderId}`}
               </div>
-              <div className={styles.messageText}>{msg.content}</div>
+
+              {/* 메시지 포맷 분기 처리 */}
+              <div className={styles.messageText}>
+                {msg.format === MessageFormat.ARCHIVE ? (
+                  <>
+                    {/* 파일명만 출력 */}
+                    <a
+                      href={msg.content}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{ color: '#1890ff', textDecoration: 'underline' }}
+                    >
+                      📎 {msg.content.split('/').pop()} {/* 파일명만 출력 */}
+                    </a>
+
+                    {/* 태그 정보 표시 */}
+                    {!!msg.tagNames && msg.tagNames.length > 0 && (
+                      <div
+                        style={{
+                          marginTop: '4px',
+                          fontSize: '12px',
+                          color: '#999',
+                        }}
+                      >
+                        {msg.tagNames.map((tag) => (
+                          <span key={tag} style={{ marginRight: '6px' }}>
+                            #{tag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  msg.content
+                )}
+              </div>
+
               <div className={styles.timeStamp}>
                 {getTimeString(msg.createdAt)}
               </div>
@@ -69,8 +100,6 @@ export default function GroupChatMessageList({
           </div>
         );
       })}
-
-      {/* 자동 스크롤 타겟 */}
       <div ref={bottomRef} />
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,58 @@
   "packages": {
     "": {
       "dependencies": {
+        "@fullcalendar/core": "^6.1.17",
+        "@fullcalendar/daygrid": "^6.1.17",
+        "@fullcalendar/interaction": "^6.1.17",
+        "@fullcalendar/react": "^6.1.17",
+        "@fullcalendar/timegrid": "^6.1.17",
         "@tanstack/react-query": "^5.77.2",
         "date-fns": "^4.1.0"
+      }
+    },
+    "node_modules/@fullcalendar/core": {
+      "version": "6.1.17",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.17.tgz",
+      "integrity": "sha512-0W7lnIrv18ruJ5zeWBeNZXO8qCWlzxDdp9COFEsZnyNjiEhUVnrW/dPbjRKYpL0edGG0/Lhs0ghp1z/5ekt8ZA==",
+      "dependencies": {
+        "preact": "~10.12.1"
+      }
+    },
+    "node_modules/@fullcalendar/daygrid": {
+      "version": "6.1.17",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.17.tgz",
+      "integrity": "sha512-K7m+pd7oVJ9fW4h7CLDdDGJbc9szJ1xDU1DZ2ag+7oOo1aCNLv44CehzkkknM6r8EYlOOhgaelxQpKAI4glj7A==",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.17"
+      }
+    },
+    "node_modules/@fullcalendar/interaction": {
+      "version": "6.1.17",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-6.1.17.tgz",
+      "integrity": "sha512-AudvQvgmJP2FU89wpSulUUjeWv24SuyCx8FzH2WIPVaYg+vDGGYarI7K6PcM3TH7B/CyaBjm5Rqw9lXgnwt5YA==",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.17"
+      }
+    },
+    "node_modules/@fullcalendar/react": {
+      "version": "6.1.17",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/react/-/react-6.1.17.tgz",
+      "integrity": "sha512-AA8soHhlfRH5dUeqHnfAtzDiXa2vrgWocJSK/F5qzw/pOxc9MqpuoS/nQBROWtHHg6yQUg3DoGqOOhi7dmylXQ==",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.17",
+        "react": "^16.7.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.7.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/@fullcalendar/timegrid": {
+      "version": "6.1.17",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/timegrid/-/timegrid-6.1.17.tgz",
+      "integrity": "sha512-K4PlA3L3lclLOs3IX8cvddeiJI9ZVMD7RA9IqaWwbvac771971foc9tFze9YY+Pqesf6S+vhS2dWtEVlERaGlQ==",
+      "dependencies": {
+        "@fullcalendar/daygrid": "~6.1.17"
+      },
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.17"
       }
     },
     "node_modules/@tanstack/query-core": {
@@ -43,6 +93,15 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
+    "node_modules/preact": {
+      "version": "10.12.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
+      "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/react": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
@@ -51,6 +110,24 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/react-dom": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "peer": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,10 @@
 {
   "dependencies": {
+    "@fullcalendar/core": "^6.1.17",
+    "@fullcalendar/daygrid": "^6.1.17",
+    "@fullcalendar/interaction": "^6.1.17",
+    "@fullcalendar/react": "^6.1.17",
+    "@fullcalendar/timegrid": "^6.1.17",
     "@tanstack/react-query": "^5.77.2",
     "date-fns": "^4.1.0"
   }


### PR DESCRIPTION
## 🧩 작업 개요
첨부파일 업로드 시 태그 입력 → 저장 → 메시지 전송 → 출력까지 전체 기능 흐름 구현

## ✅ 프론트엔드
- 자동 태그 추출 (파일명 기반)
- 수동 태그 입력 (Enter, Comma)
- 태그 중복 방지 및 삭제 기능
- 업로드 후 WebSocket 메시지에 태그 포함 전송
- 채팅 메시지에서 첨부파일 및 태그 렌더링 처리

## ✅ 백엔드
- 업로드 시 ArchiveTag 연관 저장 처리
- ArchiveItem 응답에 태그 리스트 포함
- WebSocket ChatMessagePayload에 tagNames 필드 추가

## 📝 참고
- UI 스타일 및 태그 자동완성 추천 UI는 후속 이슈에서 반영 예정
